### PR TITLE
Fix duplicate threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "loki-discord-bot"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-discord-bot"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "A bot to serve various meme-related purposes within a personal Discord server."
 readme = "README.md"

--- a/src/config.rs
+++ b/src/config.rs
@@ -153,6 +153,8 @@ struct Tokens {
 
 #[derive(Deserialize, Serialize, Default)]
 pub struct Guild {
+    #[serde(skip)]
+    threads_started: bool,
     trigger_map: Option<HashMap<String, String>>,
     memes: Option<Memes>,
 }
@@ -180,6 +182,14 @@ impl Guild {
         } else {
             None
         }
+    }
+
+    pub fn threads_started(&self) -> bool {
+        self.threads_started
+    }
+
+    pub fn set_threads_started(&mut self) {
+        self.threads_started = true;
     }
 }
 


### PR DESCRIPTION
Discord sometimes repeats the `Guild Create` event (probably when connecting to different gateways in their API?).
This prevents the repeat events from spawning duplicate threads for each guild (causing, for example, duplicate meme resets).