### PR TITLE
Redesign subsystems to use trait

### DIFF
--- a/src/subsystems/events.rs
+++ b/src/subsystems/events.rs
@@ -1,13 +1,16 @@
 use std::{fmt::Display, str::FromStr};
 
 use serde::{Deserialize, Serialize};
+use serenity::{async_trait, model::prelude::Ready, prelude::Context};
 use tinyvec::ArrayVec;
 
 use crate::{
-    command::{create_response, Command, Option, OptionType, PermissionType},
+    command::{create_response, notify_subscribers, Command, Option, OptionType, PermissionType},
     config::Config,
     Error,
 };
+
+use super::Subsystem;
 
 const EVENTS: [Event; 2] = [Event::Startup, Event::Error];
 
@@ -44,120 +47,141 @@ impl FromStr for Event {
     }
 }
 
-pub fn generate_command() -> Command<'static> {
-    let options = Box::new(
-        EVENTS
-            .iter()
-            .map(|e| e.to_string())
-            .collect::<ArrayVec<[String; 25]>>(),
-    );
+pub struct Events;
 
-    Command::new(
-        "events",
-        "Manage subscriptions to notifications for specific bot events.",
-        PermissionType::Universal,
-        None,
-    )
-    .add_variant(
-        Command::new(
-            "subscribe",
-            "Subscribe to a bot event. Some events may be restricted.",
+#[async_trait]
+impl Subsystem for Events {
+    fn generate_commands(&self) -> Vec<Command<'static>> {
+        let options = Box::new(
+            EVENTS
+                .iter()
+                .map(|e| e.to_string())
+                .collect::<ArrayVec<[String; 25]>>(),
+        );
+
+        vec![Command::new(
+            "events",
+            "Manage subscriptions to notifications for specific bot events.",
             PermissionType::Universal,
-            Some(Box::new(move |ctx, command| {
-                Box::pin(async {
-                    let event = command.data.options[0]
-                        .options
-                        .iter()
-                        .find(|opt| opt.name == "event")
-                        .unwrap()
-                        .value
-                        .as_ref()
-                        .unwrap()
-                        .as_str()
-                        .unwrap();
-                    let event = Event::from_str(event)?;
-                    let mut data = ctx.data.write().await;
-                    let config = data.get_mut::<Config>().unwrap();
-                    let subscribers = config.subscribers_mut(event);
-                    if !subscribers.contains(&command.user.id) {
-                        subscribers.push(command.user.id);
-                        config.save();
-                        create_response(
-                            &ctx.http,
-                            command,
-                            &format!("Successfully subscribed to {event}."),
-                            true,
-                        )
-                        .await;
-                    } else {
-                        create_response(
-                            &ctx.http,
-                            command,
-                            &format!("You're already subscribed to {event}."),
-                            true,
-                        )
-                        .await;
-                    }
-                    Ok(())
-                })
-            })),
+            None,
         )
-        .add_option(Option::new(
-            "event",
-            "The event type you'd like to subscribe to.",
-            OptionType::StringSelect(options.clone()),
-            true,
-        )),
-    )
-    .add_variant(
-        Command::new(
-            "unsubscribe",
-            "Unsubscribe from a bot event.",
-            PermissionType::Universal,
-            Some(Box::new(move |ctx, command| {
-                Box::pin(async {
-                    let event = command.data.options[0]
-                        .options
-                        .iter()
-                        .find(|opt| opt.name == "event")
-                        .unwrap()
-                        .value
-                        .as_ref()
-                        .unwrap()
-                        .as_str()
-                        .unwrap();
-                    let event = Event::from_str(event)?;
-                    let mut data = ctx.data.write().await;
-                    let config = data.get_mut::<Config>().unwrap();
-                    let subscribers = config.subscribers_mut(event);
-                    if subscribers.contains(&command.user.id) {
-                        subscribers.retain(|u| *u != command.user.id);
-                        config.save();
-                        create_response(
-                            &ctx.http,
-                            command,
-                            &format!("Successfully unsubscribed from {event}."),
-                            true,
-                        )
-                        .await;
-                    } else {
-                        create_response(
-                            &ctx.http,
-                            command,
-                            &format!("You aren't subscribed to {event}."),
-                            true,
-                        )
-                        .await;
-                    }
-                    Ok(())
-                })
-            })),
+        .add_variant(
+            Command::new(
+                "subscribe",
+                "Subscribe to a bot event. Some events may be restricted.",
+                PermissionType::Universal,
+                Some(Box::new(move |ctx, command| {
+                    Box::pin(async {
+                        let event = command.data.options[0]
+                            .options
+                            .iter()
+                            .find(|opt| opt.name == "event")
+                            .unwrap()
+                            .value
+                            .as_ref()
+                            .unwrap()
+                            .as_str()
+                            .unwrap();
+                        let event = Event::from_str(event)?;
+                        let mut data = ctx.data.write().await;
+                        let config = data.get_mut::<Config>().unwrap();
+                        let subscribers = config.subscribers_mut(event);
+                        if !subscribers.contains(&command.user.id) {
+                            subscribers.push(command.user.id);
+                            config.save();
+                            create_response(
+                                &ctx.http,
+                                command,
+                                &format!("Successfully subscribed to {event}."),
+                                true,
+                            )
+                            .await;
+                        } else {
+                            create_response(
+                                &ctx.http,
+                                command,
+                                &format!("You're already subscribed to {event}."),
+                                true,
+                            )
+                            .await;
+                        }
+                        Ok(())
+                    })
+                })),
+            )
+            .add_option(Option::new(
+                "event",
+                "The event type you'd like to subscribe to.",
+                OptionType::StringSelect(options.clone()),
+                true,
+            )),
         )
-        .add_option(Option::new(
-            "event",
-            "The event type you'd like to unsubscribe from.",
-            OptionType::StringSelect(options),
-            true,
-        )),
-    )
+        .add_variant(
+            Command::new(
+                "unsubscribe",
+                "Unsubscribe from a bot event.",
+                PermissionType::Universal,
+                Some(Box::new(move |ctx, command| {
+                    Box::pin(async {
+                        let event = command.data.options[0]
+                            .options
+                            .iter()
+                            .find(|opt| opt.name == "event")
+                            .unwrap()
+                            .value
+                            .as_ref()
+                            .unwrap()
+                            .as_str()
+                            .unwrap();
+                        let event = Event::from_str(event)?;
+                        let mut data = ctx.data.write().await;
+                        let config = data.get_mut::<Config>().unwrap();
+                        let subscribers = config.subscribers_mut(event);
+                        if subscribers.contains(&command.user.id) {
+                            subscribers.retain(|u| *u != command.user.id);
+                            config.save();
+                            create_response(
+                                &ctx.http,
+                                command,
+                                &format!("Successfully unsubscribed from {event}."),
+                                true,
+                            )
+                            .await;
+                        } else {
+                            create_response(
+                                &ctx.http,
+                                command,
+                                &format!("You aren't subscribed to {event}."),
+                                true,
+                            )
+                            .await;
+                        }
+                        Ok(())
+                    })
+                })),
+            )
+            .add_option(Option::new(
+                "event",
+                "The event type you'd like to unsubscribe from.",
+                OptionType::StringSelect(options),
+                true,
+            )),
+        )]
+    }
+
+    async fn ready(&self, ctx: &Context, _ready: &Ready) {
+        notify_subscribers(
+            ctx,
+            Event::Startup,
+            format!(
+                "**Hey!**
+I'm starting up with version [{}]({}/releases/tag/v{}). 😁",
+                crate::VERSION,
+                crate::GITHUB_URL,
+                crate::VERSION,
+            )
+            .as_str(),
+        )
+        .await;
+    }
 }

--- a/src/subsystems/memes.rs
+++ b/src/subsystems/memes.rs
@@ -4,6 +4,7 @@ use chrono::{Days, Utc};
 use log::{error, info};
 use rand::Rng;
 use serenity::{
+    async_trait,
     model::{
         prelude::{
             interaction::application_command::CommandDataOptionValue, ChannelType, Guild, Message,
@@ -24,245 +25,287 @@ use crate::{
     subsystems::events::Event,
 };
 
+use super::Subsystem;
+
 const REACTION_CHANCE: f64 = 0.1;
 const REACTION_EMOTE: char = '🤖';
 
-pub fn generate_command() -> Command<'static> {
-    Command::new(
-        "memes",
-        "Configuration commands for the meme-voting system.",
-        PermissionType::ServerPerms(Permissions::MANAGE_CHANNELS),
-        None,
-    )
-    .add_variant(
-        Command::new(
-            "set_channel",
-            "Sets the memes channel for this server and initialises the meme subsystem.",
+pub struct Memes;
+
+#[async_trait]
+impl Subsystem for Memes {
+    fn generate_commands(&self) -> Vec<Command<'static>> {
+        vec![Command::new(
+            "memes",
+            "Configuration commands for the meme-voting system.",
             PermissionType::ServerPerms(Permissions::MANAGE_CHANNELS),
-            Some(Box::new(move |ctx, command| {
-                Box::pin(async {
-                    let (channel_id, channel) =
-                        if let Some(CommandDataOptionValue::Channel(channel)) =
-                            &command.data.options[0].options[0].resolved
-                        {
-                            if let Some(channel) = channel.id.to_channel(&ctx.http).await?.guild() {
-                                (channel.id, channel)
+            None,
+        )
+        .add_variant(
+            Command::new(
+                "set_channel",
+                "Sets the memes channel for this server and initialises the meme subsystem.",
+                PermissionType::ServerPerms(Permissions::MANAGE_CHANNELS),
+                Some(Box::new(move |ctx, command| {
+                    Box::pin(async {
+                        let (channel_id, channel) =
+                            if let Some(CommandDataOptionValue::Channel(channel)) =
+                                &command.data.options[0].options[0].resolved
+                            {
+                                if let Some(channel) =
+                                    channel.id.to_channel(&ctx.http).await?.guild()
+                                {
+                                    (channel.id, channel)
+                                } else {
+                                    return Err(crate::Error::InvalidChannel);
+                                }
                             } else {
                                 return Err(crate::Error::InvalidChannel);
-                            }
-                        } else {
-                            return Err(crate::Error::InvalidChannel);
-                        };
-                    let mut data = ctx.data.write().await;
-                    let config = data.get_mut::<Config>().unwrap();
-                    let guild_config = config.guild_mut(&command.guild_id.unwrap());
-                    guild_config.set_memes_channel(Some(channel_id));
-                    let reset_time = guild_config.memes().unwrap().next_reset();
-                    config.save();
-                    drop(data);
-                    let resp = format!("Memes channel set to {}.", channel);
-                    channel
-                        .send_message(
-                            &ctx.http,
-                            create_embed(format!(
-                                "**Post your best memes!**
-Vote by reacting to your favourite memes.
-The post with the most total reactions by {} wins!",
-                                reset_time.format(crate::DATE_FMT),
-                            )),
-                        )
-                        .await?;
-                    create_response(&ctx.http, command, &resp, true).await;
-                    Ok(())
-                })
-            })),
-        )
-        .add_option(crate::command::Option::new(
-            "channel",
-            "The channel which is to be used for memes.",
-            OptionType::Channel(Some(vec![ChannelType::Text])),
-            true,
-        )),
-    )
-    .add_variant(Command::new(
-        "unset_channel",
-        "Unsets the memes channel for this server, resetting the meme subsystem.",
-        PermissionType::ServerPerms(Permissions::MANAGE_CHANNELS),
-        Some(Box::new(move |ctx, command| {
-            Box::pin(async {
-                let mut data = ctx.data.write().await;
-                let config = data.get_mut::<Config>().unwrap();
-                let channel = config
-                    .guild_mut(&command.guild_id.unwrap())
-                    .memes()
-                    .map(|memes| memes.channel());
-                config
-                    .guild_mut(&command.guild_id.unwrap())
-                    .set_memes_channel(None);
-                config.save();
-                drop(data);
-                let resp = "Memes channel unset.".to_string();
-                create_response(&ctx.http, command, &resp, true).await;
-                if let Some(channel) = channel {
-                    if let Some(channel) = channel.to_channel(&ctx.http).await?.guild() {
+                            };
+                        let mut data = ctx.data.write().await;
+                        let config = data.get_mut::<Config>().unwrap();
+                        let guild_config = config.guild_mut(&command.guild_id.unwrap());
+                        guild_config.set_memes_channel(Some(channel_id));
+                        let reset_time = guild_config.memes().unwrap().next_reset();
+                        config.save();
+                        drop(data);
+                        let resp = format!("Memes channel set to {}.", channel);
                         channel
                             .send_message(
                                 &ctx.http,
-                                create_embed(
-                                    "**Halt your memes!**
-I won't see them anymore. :("
-                                        .to_string(),
-                                ),
+                                create_embed(format!(
+                                    "**Post your best memes!**
+Vote by reacting to your favourite memes.
+The post with the most total reactions by {} wins!",
+                                    reset_time.format(crate::DATE_FMT),
+                                )),
                             )
                             .await?;
-                    }
-                }
-                Ok(())
-            })
-        })),
-    ))
-}
-
-/// Catch up on any messages that were missed while the bot was
-/// offline.
-pub async fn catch_up_messages(ctx: Context, g: &Guild) -> Context {
-    let mut finished = true;
-    let mut data = ctx.data.write().await;
-    info!("Catching up with messages for guild {}...", g.id);
-    let config = data.get_mut::<Config>().unwrap();
-    let guild = config.guild_mut(&g.id);
-    if let Some(memes) = guild.memes_mut() {
-        // catch up on any messages that were missed while we were offline.
-        if let Ok(channel) = memes.channel().to_channel(&ctx.http).await {
-            let channel = channel.guild().unwrap();
-            loop {
-                if let Some(last_message) = memes.list().last() {
-                    match channel
-                        .messages(&ctx.http, |retriever| {
-                            retriever.after(last_message).limit(100)
-                        })
-                        .await
-                    {
-                        Ok(messages) => {
-                            let messages: Vec<&Message> =
-                                messages.iter().filter(|m| !m.is_own(&ctx.cache)).collect();
-                            messages.iter().for_each(|m| memes.add(m.id));
-                            finished = messages.is_empty();
-                        }
-                        Err(e) => {
-                            notify_subscribers(
-                                &ctx,
-                                Event::Error,
-                                format!("Error retrieving missed messages in {}: {e:?}", g.id)
-                                    .as_str(),
-                            )
-                            .await;
-                            error!("Error retrieving missed messages in {}: {e:?}", g.id)
-                        }
-                    };
-                }
-                if finished {
+                        create_response(&ctx.http, command, &resp, true).await;
+                        Ok(())
+                    })
+                })),
+            )
+            .add_option(crate::command::Option::new(
+                "channel",
+                "The channel which is to be used for memes.",
+                OptionType::Channel(Some(vec![ChannelType::Text])),
+                true,
+            )),
+        )
+        .add_variant(Command::new(
+            "unset_channel",
+            "Unsets the memes channel for this server, resetting the meme subsystem.",
+            PermissionType::ServerPerms(Permissions::MANAGE_CHANNELS),
+            Some(Box::new(move |ctx, command| {
+                Box::pin(async {
+                    let mut data = ctx.data.write().await;
+                    let config = data.get_mut::<Config>().unwrap();
+                    let channel = config
+                        .guild_mut(&command.guild_id.unwrap())
+                        .memes()
+                        .map(|memes| memes.channel());
+                    config
+                        .guild_mut(&command.guild_id.unwrap())
+                        .set_memes_channel(None);
                     config.save();
-                    break;
+                    drop(data);
+                    let resp = "Memes channel unset.".to_string();
+                    create_response(&ctx.http, command, &resp, true).await;
+                    if let Some(channel) = channel {
+                        if let Some(channel) = channel.to_channel(&ctx.http).await?.guild() {
+                            channel
+                                .send_message(
+                                    &ctx.http,
+                                    create_embed(
+                                        "**Halt your memes!**
+I won't see them anymore. :("
+                                            .to_string(),
+                                    ),
+                                )
+                                .await?;
+                        }
+                    }
+                    Ok(())
+                })
+            })),
+        ))]
+    }
+
+    async fn guild_init(&self, ctx: Context, g: Guild) {
+        let ctx = Self::catch_up_messages(ctx.clone(), &g).await;
+
+        tokio::spawn(Self::init(ctx, g)).await.unwrap();
+    }
+
+    async fn message(&self, ctx: &Context, message: &Message) {
+        if let Some(flags) = message.flags {
+            if flags.contains(MessageFlags::EPHEMERAL) {
+                return;
+            }
+        }
+        if let Some(guild) = message.guild_id {
+            let mut data = ctx.data.write().await;
+            let config = data.get_mut::<Config>().unwrap();
+            let guild = config.guild_mut(&guild);
+            if let Some(memes) = guild.memes_mut() {
+                if message.channel_id == memes.channel() && !message.is_own(&ctx.cache) {
+                    if !memes.has_reacted()
+                        && rand::thread_rng().gen_bool(REACTION_CHANCE)
+                        && message.react(&ctx.http, REACTION_EMOTE).await.is_ok()
+                    {
+                        memes.reacted();
+                    }
+                    memes.add(message.id);
+                    config.save()
                 }
             }
         }
     }
-    drop(data);
-    info!("Finished catching up with messages for guild {}.", g.id);
-    ctx
 }
 
-pub async fn init(ctx: Context, g: Guild) {
-    loop {
-        let data = ctx.data.read().await;
-        if let Some(memes) = get_memes(&data, &g.id) {
-            let reset_time = memes.next_reset();
-            info!("Next reset: {}", reset_time);
-            drop(data);
-            let now = Utc::now();
-            let time_until_ping = reset_time
-                .checked_sub_days(Days::new(2))
-                .unwrap()
-                .signed_duration_since(now);
-            if time_until_ping.num_seconds() > 0 {
-                info!(
-                    "Sleeping for {}s until it's time to ping",
-                    time_until_ping.num_seconds()
-                );
-                tokio::time::sleep(time_until_ping.to_std().unwrap()).await;
-                let data = ctx.data.read().await;
-                if let Some(memes) = get_memes(&data, &g.id) {
-                    let channel = memes
-                        .channel()
-                        .to_channel(&ctx.http)
-                        .await
-                        .unwrap()
-                        .guild()
-                        .unwrap();
-                    if memes.list().is_empty() {
-                        channel
-                            .send_message(&ctx.http, |m| {
-                                m.add_embed(|e| {
-                                    e.description(
-                                        "**No memes?**
-Two days left! Perhaps time to post some?",
-                                    )
-                                    .image("https://media.tenor.com/ve60xH3hKrcAAAAC/no.gif")
-                                    .colour(crate::COLOUR)
-                                })
+impl Memes {
+    /// Catch up on any messages that were missed while the bot was
+    /// offline.
+    pub async fn catch_up_messages(ctx: Context, g: &Guild) -> Context {
+        let mut finished = true;
+        let mut data = ctx.data.write().await;
+        info!("Catching up with messages for guild {}...", g.id);
+        let config = data.get_mut::<Config>().unwrap();
+        let guild = config.guild_mut(&g.id);
+        if let Some(memes) = guild.memes_mut() {
+            // catch up on any messages that were missed while we were offline.
+            if let Ok(channel) = memes.channel().to_channel(&ctx.http).await {
+                let channel = channel.guild().unwrap();
+                loop {
+                    if let Some(last_message) = memes.list().last() {
+                        match channel
+                            .messages(&ctx.http, |retriever| {
+                                retriever.after(last_message).limit(100)
                             })
                             .await
-                            .ok();
+                        {
+                            Ok(messages) => {
+                                let messages: Vec<&Message> =
+                                    messages.iter().filter(|m| !m.is_own(&ctx.cache)).collect();
+                                messages.iter().for_each(|m| memes.add(m.id));
+                                finished = messages.is_empty();
+                            }
+                            Err(e) => {
+                                notify_subscribers(
+                                    &ctx,
+                                    Event::Error,
+                                    format!("Error retrieving missed messages in {}: {e:?}", g.id)
+                                        .as_str(),
+                                )
+                                .await;
+                                error!("Error retrieving missed messages in {}: {e:?}", g.id)
+                            }
+                        };
+                    }
+                    if finished {
+                        config.save();
+                        break;
                     }
                 }
+            }
+        }
+        drop(data);
+        info!("Finished catching up with messages for guild {}.", g.id);
+        ctx
+    }
+
+    async fn init(ctx: Context, g: Guild) {
+        loop {
+            let data = ctx.data.read().await;
+            if let Some(memes) = get_memes(&data, &g.id) {
+                let reset_time = memes.next_reset();
+                info!("Next reset: {}", reset_time);
                 drop(data);
-            }
-            let now = Utc::now();
-            let time_until_reset = reset_time.signed_duration_since(now);
-            if time_until_reset.num_seconds() > 0 {
-                info!(
-                    "Sleeping for {}s until it's time to reset",
-                    time_until_reset.num_seconds()
-                );
-                tokio::time::sleep(time_until_reset.to_std().unwrap()).await;
-                // in case the settings have changed during
-                // our long slumber, give the earlier checks
-                // another go:
-                continue;
-            }
-            let mut data = ctx.data.write().await;
-            let config = data.get_mut::<Config>().unwrap();
-            let guild = config.guild_mut(&g.id);
-            if let Some(memes) = guild.memes_mut() {
-                if let Ok(channel) = memes.channel().to_channel(&ctx.http).await {
-                    let channel = channel.guild().unwrap();
-                    let mut most_reactions = 0;
-                    let mut victor: Option<Message> = None;
-                    let mut reacted = memes.has_reacted();
-                    for meme in memes.list() {
-                        if let Ok(meme) = channel.message(&ctx.http, meme).await {
-                            if !reacted
-                                && rand::thread_rng().gen_bool(REACTION_CHANCE)
-                                && meme.react(&ctx.http, REACTION_EMOTE).await.is_ok()
-                            {
-                                reacted = true;
-                            }
-                            let total_reactions: u64 = meme.reactions.iter().map(|m| m.count).sum();
-                            if total_reactions > most_reactions {
-                                most_reactions = total_reactions;
-                                victor = Some(meme);
-                            }
+                let now = Utc::now();
+                let time_until_ping = reset_time
+                    .checked_sub_days(Days::new(2))
+                    .unwrap()
+                    .signed_duration_since(now);
+                if time_until_ping.num_seconds() > 0 {
+                    info!(
+                        "Sleeping for {}s until it's time to ping",
+                        time_until_ping.num_seconds()
+                    );
+                    tokio::time::sleep(time_until_ping.to_std().unwrap()).await;
+                    let data = ctx.data.read().await;
+                    if let Some(memes) = get_memes(&data, &g.id) {
+                        let channel = memes
+                            .channel()
+                            .to_channel(&ctx.http)
+                            .await
+                            .unwrap()
+                            .guild()
+                            .unwrap();
+                        if memes.list().is_empty() {
+                            channel
+                                .send_message(&ctx.http, |m| {
+                                    m.add_embed(|e| {
+                                        e.description(
+                                            "**No memes?**
+Two days left! Perhaps time to post some?",
+                                        )
+                                        .image("https://media.tenor.com/ve60xH3hKrcAAAAC/no.gif")
+                                        .colour(crate::COLOUR)
+                                    })
+                                })
+                                .await
+                                .ok();
                         }
                     }
+                    drop(data);
+                }
+                let now = Utc::now();
+                let time_until_reset = reset_time.signed_duration_since(now);
+                if time_until_reset.num_seconds() > 0 {
+                    info!(
+                        "Sleeping for {}s until it's time to reset",
+                        time_until_reset.num_seconds()
+                    );
+                    tokio::time::sleep(time_until_reset.to_std().unwrap()).await;
+                    // in case the settings have changed during
+                    // our long slumber, give the earlier checks
+                    // another go:
+                    continue;
+                }
+                let mut data = ctx.data.write().await;
+                let config = data.get_mut::<Config>().unwrap();
+                let guild = config.guild_mut(&g.id);
+                if let Some(memes) = guild.memes_mut() {
+                    if let Ok(channel) = memes.channel().to_channel(&ctx.http).await {
+                        let channel = channel.guild().unwrap();
+                        let mut most_reactions = 0;
+                        let mut victor: Option<Message> = None;
+                        let mut reacted = memes.has_reacted();
+                        for meme in memes.list() {
+                            if let Ok(meme) = channel.message(&ctx.http, meme).await {
+                                if !reacted
+                                    && rand::thread_rng().gen_bool(REACTION_CHANCE)
+                                    && meme.react(&ctx.http, REACTION_EMOTE).await.is_ok()
+                                {
+                                    reacted = true;
+                                }
+                                let total_reactions: u64 =
+                                    meme.reactions.iter().map(|m| m.count).sum();
+                                if total_reactions > most_reactions {
+                                    most_reactions = total_reactions;
+                                    victor = Some(meme);
+                                }
+                            }
+                        }
 
-                    memes.reset();
-                    if let Some(victor) = victor {
-                        channel
-                            .send_message(
-                                &ctx.http,
-                                crate::command::create_embed(format!(
-                                    "**Voting results**
+                        memes.reset();
+                        if let Some(victor) = victor {
+                            channel
+                                .send_message(
+                                    &ctx.http,
+                                    crate::command::create_embed(format!(
+                                        "**Voting results**
 Congratulations {} for winning this week's meme contest, with \
 their entry [here]({})!
 
@@ -272,71 +315,47 @@ I've reset the entries, so post your best memes and perhaps next \
 week you'll win? 😉
 
 You've got until {}.",
-                                    victor.author.mention(),
-                                    victor.link(),
-                                    memes.next_reset().format(crate::DATE_FMT),
-                                )),
-                            )
-                            .await
-                            .unwrap();
-                    } else {
-                        channel
-                            .send_message(
-                                &ctx.http,
-                                crate::command::create_embed(format!(
-                                    "**No votes**
+                                        victor.author.mention(),
+                                        victor.link(),
+                                        memes.next_reset().format(crate::DATE_FMT),
+                                    )),
+                                )
+                                .await
+                                .unwrap();
+                        } else {
+                            channel
+                                .send_message(
+                                    &ctx.http,
+                                    crate::command::create_embed(format!(
+                                        "**No votes**
 There weren't any votes (reactions), so there's no winner. Sadge.
 
 I've reset the entries, so can you, like, _do something_ this week?
 
 You've got until {}.",
-                                    memes.next_reset().format(crate::DATE_FMT)
-                                )),
-                            )
-                            .await
-                            .unwrap();
+                                        memes.next_reset().format(crate::DATE_FMT)
+                                    )),
+                                )
+                                .await
+                                .unwrap();
+                        }
+                        config.save();
                     }
-                    config.save();
                 }
+                drop(data);
+            } else {
+                drop(data);
             }
-            drop(data);
-        } else {
-            drop(data);
-        }
-        // let up for a while so we don't hog the mutex...
-        // sleep for a day, which also gives a nice window to change
-        // the reset time if we're sleeping after a proper reset.
-        // if the memes channel is re-set during this day, then the
-        // system will properly start using the new artifical time.
-        // (eg, initially set up system at 10pm -> all resets occur
-        // at 10pm. wait until reset, and if you then re-set the memes
-        // channel at 7am the next morning, resets will start occuring
-        // at 7am.)
-        tokio::time::sleep(Duration::new(86_400, 0)).await;
-    }
-}
-
-pub async fn message(ctx: &Context, message: &Message) {
-    if let Some(flags) = message.flags {
-        if flags.contains(MessageFlags::EPHEMERAL) {
-            return;
-        }
-    }
-    if let Some(guild) = message.guild_id {
-        let mut data = ctx.data.write().await;
-        let config = data.get_mut::<Config>().unwrap();
-        let guild = config.guild_mut(&guild);
-        if let Some(memes) = guild.memes_mut() {
-            if message.channel_id == memes.channel() && !message.is_own(&ctx.cache) {
-                if !memes.has_reacted()
-                    && rand::thread_rng().gen_bool(REACTION_CHANCE)
-                    && message.react(&ctx.http, REACTION_EMOTE).await.is_ok()
-                {
-                    memes.reacted();
-                }
-                memes.add(message.id);
-                config.save()
-            }
+            // let up for a while so we don't hog the mutex...
+            // sleep for a day, which also gives a nice window to change
+            // the reset time if we're sleeping after a proper reset.
+            // if the memes channel is re-set during this day, then the
+            // system will properly start using the new artifical time.
+            // (eg, initially set up system at 10pm -> all resets occur
+            // at 10pm. wait until reset, and if you then re-set the memes
+            // channel at 7am the next morning, resets will start occuring
+            // at 7am.)
+            tokio::time::sleep(Duration::new(86_400, 0)).await;
         }
     }
 }

--- a/src/subsystems/mod.rs
+++ b/src/subsystems/mod.rs
@@ -1,4 +1,32 @@
+use serenity::{
+    async_trait,
+    model::prelude::{Guild, Message, Presence, Ready},
+    prelude::Context,
+};
+
+use crate::command::Command;
+
 pub mod events;
-pub mod memes;
-pub mod status_meaning;
-pub mod stream_indicator;
+mod memes;
+mod status_meaning;
+mod stream_indicator;
+
+pub fn subsystems() -> [Box<dyn Subsystem>; 4] {
+    [
+        Box::new(events::Events),
+        Box::new(memes::Memes),
+        Box::new(status_meaning::StatusMeaning),
+        Box::new(stream_indicator::StreamIndicator),
+    ]
+}
+
+#[async_trait]
+pub trait Subsystem: Send + Sync {
+    fn generate_commands(&self) -> Vec<Command<'static>>;
+
+    async fn guild_init(&self, _ctx: Context, _g: Guild) {}
+
+    async fn ready(&self, _ctx: &Context, _ready: &Ready) {}
+    async fn message(&self, _ctx: &Context, _message: &Message) {}
+    async fn presence(&self, _ctx: &Context, _new_data: &Presence) {}
+}

--- a/src/subsystems/stream_indicator.rs
+++ b/src/subsystems/stream_indicator.rs
@@ -1,57 +1,69 @@
 use log::error;
 use serenity::{
+    async_trait,
     model::prelude::{ActivityType, GuildId, Presence},
     prelude::Context,
 };
 
 use crate::config::Config;
 
+use super::Subsystem;
+
 const STREAMING_PREFIX: &str = "🔴 ";
 
-pub async fn presence(ctx: &Context, new_data: &Presence) {
-    let data = ctx.data.read().await;
-    let config = data.get::<Config>().unwrap();
-    if new_data
-        .activities
-        .iter()
-        .any(|a| a.kind == ActivityType::Streaming)
-    {
-        if let Some(user) = new_data.user.to_user() {
-            for guild in config.guilds().map(|g| GuildId(g.parse::<u64>().unwrap())) {
-                let nick = user
-                    .nick_in(&ctx.http, guild)
-                    .await
-                    .unwrap_or(user.name.clone());
-                if !nick.starts_with(STREAMING_PREFIX) {
-                    // the user is streaming, but they aren't marked as such.
-                    let old_nick = nick.clone();
-                    let nick =
-                        STREAMING_PREFIX.to_owned() + &nick.chars().take(30).collect::<String>();
-                    if let Ok(guild) = guild.to_partial_guild(&ctx.http).await {
-                        if let Err(e) = guild
-                            .edit_member(&ctx.http, user.id, |u| u.nickname(nick.clone()))
-                            .await
-                        {
-                            error!("Nickname update failed: {old_nick} -> {nick}\n{:?}", e);
+pub struct StreamIndicator;
+
+#[async_trait]
+impl Subsystem for StreamIndicator {
+    fn generate_commands(&self) -> Vec<crate::command::Command<'static>> {
+        vec![]
+    }
+
+    async fn presence(&self, ctx: &Context, new_data: &Presence) {
+        let data = ctx.data.read().await;
+        let config = data.get::<Config>().unwrap();
+        if new_data
+            .activities
+            .iter()
+            .any(|a| a.kind == ActivityType::Streaming)
+        {
+            if let Some(user) = new_data.user.to_user() {
+                for guild in config.guilds().map(|g| GuildId(g.parse::<u64>().unwrap())) {
+                    let nick = user
+                        .nick_in(&ctx.http, guild)
+                        .await
+                        .unwrap_or(user.name.clone());
+                    if !nick.starts_with(STREAMING_PREFIX) {
+                        // the user is streaming, but they aren't marked as such.
+                        let old_nick = nick.clone();
+                        let nick = STREAMING_PREFIX.to_owned()
+                            + &nick.chars().take(30).collect::<String>();
+                        if let Ok(guild) = guild.to_partial_guild(&ctx.http).await {
+                            if let Err(e) = guild
+                                .edit_member(&ctx.http, user.id, |u| u.nickname(nick.clone()))
+                                .await
+                            {
+                                error!("Nickname update failed: {old_nick} -> {nick}\n{:?}", e);
+                            }
                         }
                     }
                 }
             }
-        }
-    } else if let Some(user) = new_data.user.to_user() {
-        for guild in config.guilds().map(|g| GuildId(g.parse::<u64>().unwrap())) {
-            let nick = user.nick_in(&ctx.http, guild).await;
-            if let Some(nick) = nick {
-                if nick.starts_with(STREAMING_PREFIX) {
-                    // the user isn't streaming any more, but they are still marked as such.
-                    let old_nick = nick.clone();
-                    let nick = nick.chars().skip(2).collect::<String>();
-                    if let Ok(guild) = guild.to_partial_guild(&ctx.http).await {
-                        if let Err(e) = guild
-                            .edit_member(&ctx.http, user.id, |u| u.nickname(nick.clone()))
-                            .await
-                        {
-                            error!("Nickname update failed: {old_nick} -> {nick}\n{:?}", e);
+        } else if let Some(user) = new_data.user.to_user() {
+            for guild in config.guilds().map(|g| GuildId(g.parse::<u64>().unwrap())) {
+                let nick = user.nick_in(&ctx.http, guild).await;
+                if let Some(nick) = nick {
+                    if nick.starts_with(STREAMING_PREFIX) {
+                        // the user isn't streaming any more, but they are still marked as such.
+                        let old_nick = nick.clone();
+                        let nick = nick.chars().skip(2).collect::<String>();
+                        if let Ok(guild) = guild.to_partial_guild(&ctx.http).await {
+                            if let Err(e) = guild
+                                .edit_member(&ctx.http, user.id, |u| u.nickname(nick.clone()))
+                                .await
+                            {
+                                error!("Nickname update failed: {old_nick} -> {nick}\n{:?}", e);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Considerably simplifies maintenance for these subsystems, as it cuts out the middle-work in `serenity_handler.rs` for changes.

Self-contains each subsystem within its own module.