### PR TITLE
Add nickname lottery feature + formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.71"
+version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -109,9 +109,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
@@ -142,9 +142,12 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -217,6 +220,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,9 +268,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -277,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -486,9 +498,9 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -513,7 +525,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -529,7 +541,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -606,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
@@ -627,9 +639,9 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -643,13 +655,13 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "loki-discord-bot"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "env_logger",
@@ -707,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
@@ -741,9 +753,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.55"
+version = "0.10.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
+checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -767,18 +779,18 @@ dependencies = [
 
 [[package]]
 name = "openssl-src"
-version = "111.26.0+1.1.1u"
+version = "111.27.0+1.1.1v"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
+checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.90"
+version = "0.9.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
+checksum = "866b5f16f90776b9bb8dc1e1802ac6f0513de3a7a7465867bfbc563dc737faac"
 dependencies = [
  "cc",
  "libc",
@@ -827,9 +839,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
 
 [[package]]
 name = "pin-utils"
@@ -851,18 +863,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -908,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -920,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -959,7 +971,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -1000,11 +1012,11 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1025,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.5"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
@@ -1046,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.1"
+version = "0.101.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+checksum = "261e9e0888cba427c3316e6322805653c9425240b6fd96cee7cb671ab70ab8d0"
 dependencies = [
  "ring",
  "untrusted",
@@ -1056,21 +1068,21 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
@@ -1084,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
@@ -1103,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1114,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.102"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -1169,7 +1181,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "time 0.3.23",
+ "time 0.3.25",
  "tokio",
  "tracing",
  "typemap_rev",
@@ -1213,6 +1225,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,9 +1242,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "syn"
-version = "2.0.25"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1240,18 +1262,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1271,10 +1293,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.23"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
+ "deranged",
  "itoa",
  "serde",
  "time-core",
@@ -1289,9 +1312,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
 dependencies = [
  "time-core",
 ]
@@ -1313,18 +1336,17 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
- "autocfg",
  "backtrace",
  "bytes",
  "libc",
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.3",
  "tokio-macros",
  "windows-sys",
 ]
@@ -1357,7 +1379,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "tokio",
 ]
 
@@ -1398,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.12"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -1504,9 +1526,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -1733,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1748,51 +1770,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.4.9"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
+checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-discord-bot"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "A bot to serve various meme-related purposes within a personal Discord server."
 readme = "README.md"
@@ -11,7 +11,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["guild-presences", "guild-members", "message-content", "events", "memes", "status-meaning", "stream-indicator", "text-response", "thread-reviver", "timeout-monitor"]
+default = ["events", "memes", "nickname-lottery", "status-meaning", "stream-indicator", "text-response", "thread-reviver", "timeout-monitor"]
 
 # Privileged Intents
 guild-presences = []
@@ -22,6 +22,7 @@ message-content = []
 # Any features requiring a specific privileged intent will automatically enable that intent's feature.
 events = []
 memes = []
+nickname-lottery = []
 status-meaning = []
 stream-indicator = ["guild-presences"]
 text-response = ["message-content"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Privileged Intents below).
 - [x] Command to explain my Discord status. (`status-meaning`)
     - [x] Management command so that the bot owner can update the
           response to this.
-- [ ] Nickname auto-changer lottery
+- [x] Nickname auto-changer lottery. (`nickname-lottery`)
 - [x] Responses to specific text in messages (but not actual commands) (`text-response`)
 - [ ] Periodic checks for how many known issues are present in FH5
 and compares to the same list for GT7. Output in number of pages.

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -66,11 +66,15 @@ impl<'a> Command<'a> {
     /// Command::new(
     ///     "name",
     ///     "A description of what the command does.",
-    ///     Box::new(move |ctx, command| {
-    ///         Box::pin(async {
-    ///             // do something here
+    ///     PermissionType::Universal,
+    ///     Some(
+    ///         Box::new(move |ctx, command| {
+    ///             Box::pin(async {
+    ///                 // do something here
+    ///                 Ok(())
+    ///             })
     ///         })
-    ///     }),
+    ///     ),
     /// ),
     /// ```
     pub fn new(

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,8 @@ use serenity::prelude::{GatewayIntents, TypeMap, TypeMapKey};
 use crate::subsystems::events::Event;
 #[cfg(feature = "memes")]
 use crate::subsystems::memes::Memes;
+#[cfg(feature = "nickname-lottery")]
+use crate::subsystems::nickname_lottery::NicknameLotteryGuildData;
 #[cfg(feature = "timeout-monitor")]
 use crate::subsystems::timeout_monitor::{
     AnnouncementsConfig as TimeoutAnnouncementsConfig, UserTimeoutData,
@@ -179,6 +181,9 @@ pub struct Guild {
     timeouts: Option<HashMap<String, UserTimeoutData>>,
     #[cfg(feature = "timeout-monitor")]
     timeouts_announcement_config: Option<TimeoutAnnouncementsConfig>,
+    #[cfg(feature = "nickname-lottery")]
+    #[serde(default)]
+    nickname_lottery_data: NicknameLotteryGuildData,
 }
 
 impl Guild {
@@ -226,6 +231,17 @@ impl Guild {
         } else {
             None
         }
+    }
+}
+
+#[cfg(feature = "nickname-lottery")]
+impl Guild {
+    pub fn nickname_lottery_data(&self) -> &NicknameLotteryGuildData {
+        &self.nickname_lottery_data
+    }
+
+    pub fn nickname_lottery_data_mut(&mut self) -> &mut NicknameLotteryGuildData {
+        &mut self.nickname_lottery_data
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,9 @@ start streaming (excluding server owner).";
     if cfg!(feature = "timeout-monitor") {
         features += "\n**•** Timeout monitoring and statistics.";
     }
+    if cfg!(feature = "nickname-lottery") {
+        features += "\n**•** Randomised, automatic nickname changing.";
+    }
 
     features
 }

--- a/src/serenity_handler.rs
+++ b/src/serenity_handler.rs
@@ -55,7 +55,10 @@ impl EventHandler for SerenityHandler<'_> {
         drop(data);
         if !started {
             // start long-running threads for this guild.
-            if cfg!(feature = "memes") || cfg!(feature = "thread-reviver") {
+            if cfg!(feature = "memes")
+                || cfg!(feature = "thread-reviver")
+                || cfg!(feature = "nickname-lottery")
+            {
                 let mut handles: JoinSet<()> = JoinSet::new();
                 #[cfg(feature = "memes")]
                 handles.spawn(subsystems::memes::MemesVoting::guild_init(
@@ -64,6 +67,11 @@ impl EventHandler for SerenityHandler<'_> {
                 ));
                 #[cfg(feature = "thread-reviver")]
                 handles.spawn(subsystems::thread_reviver::ThreadReviver::guild_init(
+                    ctx.clone(),
+                    g.clone(),
+                ));
+                #[cfg(feature = "nickname-lottery")]
+                handles.spawn(subsystems::nickname_lottery::NicknameLottery::guild_init(
                     ctx.clone(),
                     g.clone(),
                 ));

--- a/src/subsystems/mod.rs
+++ b/src/subsystems/mod.rs
@@ -10,6 +10,8 @@ use crate::command::Command;
 pub mod events;
 #[cfg(feature = "memes")]
 pub mod memes;
+#[cfg(feature = "nickname-lottery")]
+pub mod nickname_lottery;
 #[cfg(feature = "status-meaning")]
 mod status_meaning;
 #[cfg(feature = "stream-indicator")]
@@ -27,6 +29,8 @@ pub fn subsystems() -> Vec<Box<dyn Subsystem>> {
         Box::new(events::Events),
         #[cfg(feature = "memes")]
         Box::new(memes::MemesVoting),
+        #[cfg(feature = "nickname-lottery")]
+        Box::new(nickname_lottery::NicknameLottery),
         #[cfg(feature = "status-meaning")]
         Box::new(status_meaning::StatusMeaning),
         #[cfg(feature = "stream-indicator")]

--- a/src/subsystems/nickname_lottery.rs
+++ b/src/subsystems/nickname_lottery.rs
@@ -1,0 +1,348 @@
+use std::{collections::HashMap, str::FromStr, time::Duration};
+
+use log::{error, info};
+use rand::{
+    distributions::Distribution,
+    seq::{IteratorRandom, SliceRandom},
+};
+use serde::{Deserialize, Serialize};
+use serenity::{
+    async_trait,
+    futures::StreamExt,
+    model::{
+        prelude::{interaction::application_command::CommandDataOptionValue, Guild, UserId},
+        Permissions,
+    },
+    prelude::Context,
+};
+
+#[cfg(feature = "events")]
+use crate::{command::notify_subscribers, subsystems::events::Event};
+
+use crate::{command::OptionType, config::Config};
+use crate::{
+    command::{Command, PermissionType},
+    get_guild,
+};
+
+use super::Subsystem;
+
+#[derive(Default)]
+pub struct NicknameLottery;
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct NicknameLotteryGuildData {
+    /// HashMap of stringified [UserId]s to their respective list of specific nicknames, or [None] if they are excluded from the system.
+    user_specific_nicknames: HashMap<String, Vec<String>>,
+}
+
+impl NicknameLotteryGuildData {
+    /// Deconstructs a list of nicknames, separated by newlines, to into a [Vec].
+    pub fn deconstruct_nickname_string(nicks: &str) -> Vec<String> {
+        nicks
+            .split('\n')
+            .filter_map(|n| {
+                let n = n.trim();
+                if n.is_empty() {
+                    return None;
+                }
+                Some(n.to_string().chars().take(30).collect())
+            })
+            .collect()
+    }
+
+    /// Constructs a [String] listing the nicknames separated by newlines.
+    pub fn construct_nickname_string(nicks: &[String]) -> String {
+        nicks.join("\n")
+    }
+
+    /// Returns the list of specific nicknames for a given [UserId] as a [String], with each entry on a separate line.
+    pub fn user_nicknames_string(&self, user: &UserId) -> String {
+        self.user_specific_nicknames
+            .get(&user.to_string())
+            .map_or(String::default(), |n| Self::construct_nickname_string(n))
+    }
+
+    /// Sets the list of specific nicknames based for a given [UserId].
+    pub fn set_user_nicknames(&mut self, user: &UserId, nicks: &[&str]) {
+        if nicks.is_empty() {
+            self.user_specific_nicknames.remove(&user.to_string());
+        } else {
+            self.user_specific_nicknames.insert(
+                user.to_string(),
+                nicks.iter().map(|s| s.to_string()).collect(),
+            );
+        }
+    }
+
+    /// Select a nickname for the given [UserId], or [None] if the user is excluded.
+    pub fn get_nickname_for_user(&self, user: &UserId) -> Option<String> {
+        self.user_specific_nicknames
+            .get(&user.to_string())
+            .map(|n| n.choose(&mut rand::thread_rng()))
+            .unwrap_or_default()
+            .map(|s| s.to_string())
+    }
+
+    /// Select a [UserId] to change the nickname of.
+    pub fn get_random_user(&self) -> Option<UserId> {
+        self.user_specific_nicknames
+            .keys()
+            .choose(&mut rand::thread_rng())
+            .map(|id| UserId(u64::from_str(id).unwrap()))
+    }
+}
+
+#[async_trait]
+impl Subsystem for NicknameLottery {
+    fn generate_commands(&self) -> Vec<Command<'static>> {
+        vec![
+            Command::new(
+                "nickname_lottery",
+                "Controls for the nickname lottery.",
+                PermissionType::ServerPerms(Permissions::MANAGE_NICKNAMES),
+                None,
+            )
+            .add_variant(
+                Command::new(
+                    "set_nicknames",
+                    "Set the list of nicknames that can be applied, either generally or to a specific user.",
+                    PermissionType::ServerPerms(Permissions::MANAGE_NICKNAMES),
+                    Some(Box::new(move |ctx, command| {
+                        Box::pin(async move {
+                            let user = command.data.options[0].options.iter().find(|opt| opt.name == "user").and_then(|u| {
+                                if let Some(CommandDataOptionValue::User(user, _)) = &u.resolved {
+                                    Some(user.clone())
+                                } else {
+                                    None
+                                }
+                            }).unwrap();
+                            let guild_id = command.guild_id.unwrap();
+
+                            let data = ctx.data.read().await;
+                            let guild = get_guild(&data, &guild_id).unwrap();
+                            let nickname_lottery_data = guild.nickname_lottery_data();
+
+                            let old_nicknames = nickname_lottery_data.user_nicknames_string(&user.id);
+
+                            let mut input_nicks = serenity::builder::CreateInputText::default();
+                            input_nicks
+                                .label("Nicknames list")
+                                .custom_id("nicknames_list")
+                                .style(serenity::model::prelude::component::InputTextStyle::Paragraph)
+                                .placeholder("List of nicknames, each on a new line (or blank to unset).")
+                                .required(false)
+                                .value(old_nicknames);
+                            drop(data);
+
+                            let mut components = serenity::builder::CreateComponents::default();
+                            components.create_action_row(|r| r.add_input_text(input_nicks));
+
+                            command
+                                .create_interaction_response(&ctx.http, |r| {
+                                    r.kind(
+                                        serenity::model::application::interaction::InteractionResponseType::Modal,
+                                    );
+                                    r.interaction_response_data(|d| {
+                                        d.title(format!("{}'s nicknames",
+                                            user.name
+                                        ))
+                                        .custom_id(user.id.to_string() + "_set_nicknames")
+                                        .set_components(components)
+                                    })
+                                })
+                                .await?;
+
+                            let userid = user.id;
+                            // collect the submitted data
+                            let collector =
+                                serenity::collector::ModalInteractionCollectorBuilder::new(ctx)
+                                    .filter(move |int| int.data.custom_id == userid.to_string() + "_set_nicknames")
+                                    .collect_limit(1)
+                                    .build();
+
+                            collector.then(|int| async move {
+                                let mut data = ctx.data.write().await;
+                                let config = data.get_mut::<Config>().unwrap();
+                                let guild = config.guild_mut(&guild_id.clone());
+                                let nickname_lottery_data = guild.nickname_lottery_data_mut();
+
+                                let inputs: Vec<_> = int
+                                    .data
+                                    .components
+                                    .iter()
+                                    .flat_map(|r| r.components.iter())
+                                    .collect();
+
+                                for input in inputs.iter() {
+                                    if let serenity::model::prelude::component::ActionRowComponent::InputText(it) = input {
+                                        if it.custom_id == "nicknames_list" {
+                                                nickname_lottery_data.set_user_nicknames(&user.id, &NicknameLotteryGuildData::deconstruct_nickname_string(&it.value.clone()).iter().map(|n| n.as_str()).collect::<Vec<&str>>());
+                                        }
+                                    }
+                                }
+
+                                config.save();
+
+                                // it's now safe to close the modal, so send a response to it
+                                int.create_interaction_response(&ctx.http, |r| {
+                                    r.kind(serenity::model::prelude::interaction::InteractionResponseType::DeferredUpdateMessage)
+                                })
+                                .await
+                                .ok();
+                            })
+                            .collect::<Vec<_>>()
+                            .await;
+
+                            Ok(())
+                        })
+                    })),
+                )
+                .add_option(
+                    crate::Option::new(
+                        "user",
+                        "The user to set the nickname list for.",
+                        OptionType::User,
+                        true
+                    )
+                ),
+            )
+        ]
+    }
+}
+
+impl NicknameLottery {
+    pub async fn guild_init(ctx: Context, g: Guild) {
+        // between 30 minutes and 7 days
+        let between = rand::distributions::Uniform::from(1_800..604_800);
+        loop {
+            if cfg!(not(debug_assertions)) {
+                let tts = Duration::from_secs(between.sample(&mut rand::thread_rng()));
+                info!(
+                    "[Guild: {}] Next nickname change in {} minutes.",
+                    g.id,
+                    (tts.as_secs() / 60)
+                );
+                tokio::time::sleep(tts).await;
+            } else {
+                info!(
+                    "[Guild: {}] Running nickname lottery immediately once, for debugging.",
+                    g.id
+                );
+            }
+            // Time to update a user's nickname!
+            let data = ctx.data.read().await;
+            if let Some(guild) = get_guild(&data, &g.id) {
+                let lottery_data = guild.nickname_lottery_data();
+                if let Some(user) = lottery_data.get_random_user() {
+                    if let Ok(member) = g.member(&ctx.http, user).await {
+                        let user = &member.user;
+                        if let Some(mut new_nick) = lottery_data.get_nickname_for_user(&user.id) {
+                            let old_nick = member.display_name();
+                            // If feature `stream-indicator` is enabled, we want to preserve any applied streaming prefix, in case we're changing the nickname mid-stream.
+                            #[cfg(feature = "stream-indicator")]
+                            if old_nick
+                                .starts_with(crate::subsystems::stream_indicator::STREAMING_PREFIX)
+                            {
+                                new_nick = crate::subsystems::stream_indicator::STREAMING_PREFIX
+                                    .to_string()
+                                    + &new_nick;
+                            }
+                            info!(
+                                "[Guild: {}] Updating {}'s nickname to {new_nick} (current: {})",
+                                &g.id, &user.id, &old_nick
+                            );
+                            if let Err(e) = g
+                                .edit_member(&ctx.http, user.id, |m| m.nickname(new_nick))
+                                .await
+                            {
+                                #[cfg(feature = "events")]
+                                notify_subscribers(
+                                    &ctx,
+                                    Event::Error,
+                                    &format!(
+                                        "**[Guild: {}] Error changing {}'s nickname:**
+{e}",
+                                        g.id, user.id
+                                    ),
+                                )
+                                .await;
+                                error!(
+                                    "[Guild: {}] Error changing {}'s nickname:
+{e}",
+                                    g.id, user.id
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            if cfg!(debug_assertions) {
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use serenity::model::prelude::UserId;
+
+    use super::NicknameLotteryGuildData;
+
+    #[test]
+    fn test_nickname_strings() {
+        assert_eq!(
+            NicknameLotteryGuildData::construct_nickname_string(
+                &NicknameLotteryGuildData::deconstruct_nickname_string(
+                    &"Nick1
+Nick number 2    
+     Nick_numerus_tres
+
+A very long nickname that exceeds 30 characters
+etc"
+                )
+            ),
+            "Nick1
+Nick number 2
+Nick_numerus_tres
+A very long nickname that exce
+etc"
+        )
+    }
+
+    #[test]
+    fn test_setting_and_selecting_nicknames() {
+        let users = [UserId::from(0), UserId::from(1)];
+        let mut data: NicknameLotteryGuildData = NicknameLotteryGuildData::default();
+        assert_eq!(data.get_nickname_for_user(&users[0]), None);
+        assert_eq!(data.get_nickname_for_user(&users[1]), None);
+        data.set_user_nicknames(&users[0], &["user0"]);
+        data.set_user_nicknames(&users[1], &["user1"]);
+        assert_eq!(
+            data.get_nickname_for_user(&users[0]),
+            Some("user0".to_string())
+        );
+        assert_eq!(
+            data.get_nickname_for_user(&users[1]),
+            Some("user1".to_string())
+        );
+        data.set_user_nicknames(&users[0], &[]);
+        assert_eq!(data.get_nickname_for_user(&users[0]), None);
+        assert_eq!(
+            data.get_nickname_for_user(&users[1]),
+            Some("user1".to_string())
+        );
+    }
+
+    #[test]
+    fn select_random_user() {
+        let users = [UserId::from(0)];
+        let mut data: NicknameLotteryGuildData = NicknameLotteryGuildData::default();
+        assert_eq!(data.get_random_user(), None);
+        data.set_user_nicknames(&users[0], &["user0"]);
+        assert_eq!(data.get_random_user(), Some(users[0].clone()));
+        data.set_user_nicknames(&users[0], &[]);
+        assert_eq!(data.get_random_user(), None);
+    }
+}

--- a/src/subsystems/status_meaning.rs
+++ b/src/subsystems/status_meaning.rs
@@ -46,8 +46,8 @@ impl Subsystem for StatusMeaning {
                         command
                             .create_interaction_response(&ctx.http, |r| {
                                 r.kind(
-                        serenity::model::application::interaction::InteractionResponseType::Modal,
-                    );
+                                    serenity::model::application::interaction::InteractionResponseType::Modal,
+                                );
                                 r.interaction_response_data(|d| {
                                     d.title("Set Discord status meaning")
                                         .custom_id("set_status_meaning")
@@ -60,41 +60,41 @@ impl Subsystem for StatusMeaning {
                         let collector =
                             serenity::collector::ModalInteractionCollectorBuilder::new(ctx)
                                 .filter(|int| int.data.custom_id == "set_status_meaning")
+                                .collect_limit(1)
                                 .build();
 
-                        collector
-                .then(|int| async move {
-                    let mut data = ctx.data.write().await;
-                    let config = data.get_mut::<Config>().unwrap();
+                        collector.then(|int| async move {
+                            let mut data = ctx.data.write().await;
+                            let config = data.get_mut::<Config>().unwrap();
 
-                    let inputs: Vec<_> = int
-                        .data
-                        .components
-                        .iter()
-                        .flat_map(|r| r.components.iter())
-                        .collect();
+                            let inputs: Vec<_> = int
+                                .data
+                                .components
+                                .iter()
+                                .flat_map(|r| r.components.iter())
+                                .collect();
 
-                    for input in inputs.iter() {
-                        if let serenity::model::prelude::component::ActionRowComponent::InputText(it) = input {
-                            if it.custom_id == "new_status_meaning" {
-                                if !it.value.is_empty() {
-                                    config.set_status_meaning(Some(it.value.clone()));
-                                } else {
-                                    config.set_status_meaning(None);
+                            for input in inputs.iter() {
+                                if let serenity::model::prelude::component::ActionRowComponent::InputText(it) = input {
+                                    if it.custom_id == "new_status_meaning" {
+                                        if !it.value.is_empty() {
+                                            config.set_status_meaning(Some(it.value.clone()));
+                                        } else {
+                                            config.set_status_meaning(None);
+                                        }
+                                    }
                                 }
                             }
-                        }
-                    }
 
-                    // it's now safe to close the modal, so send a response to it
-                    int.create_interaction_response(&ctx.http, |r| {
-                        r.kind(serenity::model::prelude::interaction::InteractionResponseType::DeferredUpdateMessage)
-                    })
-                    .await
-                    .ok();
-                })
-                .collect::<Vec<_>>()
-                .await;
+                            // it's now safe to close the modal, so send a response to it
+                            int.create_interaction_response(&ctx.http, |r| {
+                                r.kind(serenity::model::prelude::interaction::InteractionResponseType::DeferredUpdateMessage)
+                            })
+                            .await
+                            .ok();
+                        })
+                        .collect::<Vec<_>>()
+                        .await;
 
                         Ok(())
                     })

--- a/src/subsystems/stream_indicator.rs
+++ b/src/subsystems/stream_indicator.rs
@@ -9,7 +9,7 @@ use crate::{command::notify_subscribers, config::Config};
 
 use super::Subsystem;
 
-const STREAMING_PREFIX: &str = "🔴 ";
+pub const STREAMING_PREFIX: &str = "🔴 ";
 
 pub struct StreamIndicator;
 

--- a/src/subsystems/text_response.rs
+++ b/src/subsystems/text_response.rs
@@ -106,6 +106,7 @@ Perhaps try adding some?".to_string(), true).await;
                         let collector =
                             serenity::collector::ModalInteractionCollectorBuilder::new(ctx)
                                 .filter(|int| int.data.custom_id == "set_response_value")
+                                .collect_limit(1)
                                 .build();
 
                         collector


### PR DESCRIPTION
- Added nickname lottery.
  - Individual users can be assigned lists of potential nicknames.
  - After a random amount of time (between 30 minutes to a week), select a random user and change their nickname to a random option from their list.
- Formatting improvements.
  - Pretty noisy diff as a result. Ah well.
- Ensure collectors only await 1 response before finishing.
  - It turns out this was also causing a bug whereby, say, setting multiple text responses in a row would actually make them all say the same thing.
  - This was more prominent with the username lists in testing, so it's finally fixed!
  - TODO: At some point, setting some random IDs for the modals would be ideal to better ensure uniqueness (and thus avoid multiple collectors processing the same modal response, if a prior modal was closed without submitting and hadn't timed out yet).
    - Ideally, I want to refactor these anyway, so this is something to come back to later in a future PR.