### PR TITLE
Nickname lottery fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "loki-discord-bot"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "chrono",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-discord-bot"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "A bot to serve various meme-related purposes within a personal Discord server."
 readme = "README.md"

--- a/src/subsystems/memes.rs
+++ b/src/subsystems/memes.rs
@@ -169,6 +169,7 @@ impl MemesVoting {
         info!("Catching up with messages for guild {}...", g.id);
         let config = data.get_mut::<Config>().unwrap();
         let guild = config.guild_mut(&g.id);
+        // TODO: we should really split this into two stages to limit the amount of time we have a writable handle on this - retrieve messages via Discord API using a read handle into a local vector, then grab a write handle and actually do the modifications we need.
         if let Some(memes) = guild.memes_mut() {
             // catch up on any messages that were missed while we were offline.
             if let Ok(channel) = memes.channel().to_channel(&ctx.http).await {


### PR DESCRIPTION
Allow setting it up such that, if the bot fails to set a user's nickname (such as due to a permissions issue), it requests that the change be done for it.