### PR TITLE
Leaderboards

### DIFF
--- a/src/command/util.rs
+++ b/src/command/util.rs
@@ -26,16 +26,21 @@ pub fn create_embed(
     move |m: &mut CreateMessage| m.add_embed(|e| e.description(s).colour(COLOUR))
 }
 
-/// Create a text-based embed response with the given `message`.
-pub async fn create_response(
+/// Construct a closure for use in [serenity::model::channel::GuildChannel]::send_message
+/// from the provided input string.
+pub fn create_raw_embed(s: impl ToString) -> CreateEmbed {
+    let mut embed = CreateEmbed::default();
+    embed.description(s).colour(COLOUR);
+    embed
+}
+
+/// Create an embed response.
+pub async fn create_response_from_embed(
     http: &Arc<Http>,
     interaction: &mut ApplicationCommandInteraction,
-    message: &String,
+    embed: CreateEmbed,
     ephemeral: bool,
 ) {
-    let mut embed = CreateEmbed::default();
-    embed.description(message);
-    embed.colour(COLOUR);
     match interaction
         .create_interaction_response(&http, |response| {
             response
@@ -60,6 +65,17 @@ pub async fn create_response(
             _ => error!("{}", e),
         },
     }
+}
+
+/// Create a text-based embed response with the given `message`.
+pub async fn create_response(
+    http: &Arc<Http>,
+    interaction: &mut ApplicationCommandInteraction,
+    message: &String,
+    ephemeral: bool,
+) {
+    let embed = create_raw_embed(message);
+    create_response_from_embed(http, interaction, embed, ephemeral).await
 }
 
 /// Edit the original text-based embed response, replacing it with

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,7 @@ pub enum Error {
     InvalidChannel,
     InvalidUser,
     InvalidEvent(String),
+    MissingRequiredParam(String),
     MissingActionRoutine,
     SerenityError(serenity::Error),
 }
@@ -28,6 +29,13 @@ access to it?"
             Self::InvalidEvent(s) => write!(
                 f,
                 "**Error: Invalid event**
+{s}"
+            ),
+            Self::MissingRequiredParam(s) => write!(
+                f,
+                "**Error: Missing Required Parameter for Command Invocation**
+Either Discord has failed to provide a parameter marked required, or a \
+parameter isn't marked required when it should be.
 {s}"
             ),
             Self::MissingActionRoutine => write!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,30 @@ const COLOUR: Colour = Colour::new(0x0099ff);
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const GITHUB_URL: &str = env!("CARGO_PKG_REPOSITORY");
 
+macro_rules! acquire_data_handle {
+    ($ctx:ident) => { acquire_data_handle!(read $ctx) };
+    (read $ctx:ident) => {{
+        log::trace!("Acquiring data read handle...");
+        let data = $ctx.data.read().await;
+        log::trace!("Acquired data read handle.");
+        data
+    }};
+    (write $ctx:ident) => {{
+        log::trace!("Acquiring data write handle...");
+        let data = $ctx.data.write().await;
+        log::trace!("Acquired data write handle.");
+        data
+    }};
+}
+macro_rules! drop_data_handle {
+    ($data:ident) => {
+        drop($data);
+        log::trace!("Dropping data handle.");
+    };
+}
+pub(crate) use acquire_data_handle;
+pub(crate) use drop_data_handle;
+
 pub type Result = core::result::Result<(), Error>;
 
 /// Construct a string list describing the enabled features.

--- a/src/subsystems/timeout_monitor.rs
+++ b/src/subsystems/timeout_monitor.rs
@@ -231,7 +231,7 @@ Announcement text: {}",
             })),
         ))
         .add_variant(Command::new(
-            "rankings",
+            "leaderboard",
             "Display the leaderboard for timeout statistics.",
             PermissionType::ServerPerms(Permissions::USE_SLASH_COMMANDS),
             Some(Box::new(move |ctx, command| {


### PR DESCRIPTION
Adds new leaderboard subcommands for both of the following subsystems:
- `Memes`
  - Top 10 winners by number of independent victories.
  - **Note:** The number of wins a user had was not previously being tracked, and this is a backwards-incompatible config file change. It is _required_ that a section for each Guild, titled `[guilds.<GUILD_ID>.memes.times_won]` be added; there is no requirement to add any values to these new sections if you do not want to retroactively add existing victory data, but **they must at least exist**.
- `Timeout Monitoring`
  - Tracks the total number of timeouts and total time the user has been timed out, with sorting specified when invoking the command to determine which you care about.

A new macro-based system to acquire and drop Read/Write handles to the global config is added, to aid with tracing where deadlocks occur. Expect a follow-up...