### PR TITLE
Apply tracing to all lock uses.

### DIFF
--- a/src/serenity_handler.rs
+++ b/src/serenity_handler.rs
@@ -47,12 +47,12 @@ impl EventHandler for SerenityHandler<'_> {
     }
 
     async fn guild_create(&self, ctx: Context, g: Guild, _is_new: bool) {
-        let mut data = ctx.data.write().await;
+        let mut data = crate::acquire_data_handle!(write ctx);
         let config = data.get_mut::<Config>().unwrap();
         let guild = config.guild_mut(&g.id);
         let started = guild.threads_started();
         guild.set_threads_started();
-        drop(data);
+        crate::drop_data_handle!(data);
         if !started {
             // start long-running threads for this guild.
             if cfg!(feature = "memes")

--- a/src/subsystems/events.rs
+++ b/src/subsystems/events.rs
@@ -85,7 +85,7 @@ impl Subsystem for Events {
                             .as_str()
                             .unwrap();
                         let event = Event::from_str(event)?;
-                        let mut data = ctx.data.write().await;
+                        let mut data = crate::acquire_data_handle!(write ctx);
                         let config = data.get_mut::<Config>().unwrap();
                         let subscribers = config.subscribers_mut(event);
                         if !subscribers.contains(&command.user.id) {
@@ -136,7 +136,7 @@ impl Subsystem for Events {
                             .as_str()
                             .unwrap();
                         let event = Event::from_str(event)?;
-                        let mut data = ctx.data.write().await;
+                        let mut data = crate::acquire_data_handle!(write ctx);
                         let config = data.get_mut::<Config>().unwrap();
                         let subscribers = config.subscribers_mut(event);
                         if subscribers.contains(&command.user.id) {

--- a/src/subsystems/status_meaning.rs
+++ b/src/subsystems/status_meaning.rs
@@ -18,7 +18,7 @@ impl Subsystem for StatusMeaning {
                 PermissionType::Universal,
                 Some(Box::new(move |ctx, command| {
                     Box::pin(async move {
-                        let data = ctx.data.read().await;
+                        let data = crate::acquire_data_handle!(read ctx);
                         let config = data.get::<Config>().unwrap();
                         let manager = config.get_manager().to_user(&ctx.http).await?;
                         if command.user != manager {
@@ -38,7 +38,7 @@ impl Subsystem for StatusMeaning {
                         if let Some(old_meaning) = config.get_status_meaning() {
                             meaning.value(old_meaning);
                         }
-                        drop(data);
+                        crate::drop_data_handle!(data);
 
                         let mut components = serenity::builder::CreateComponents::default();
                         components.create_action_row(|r| r.add_input_text(meaning));
@@ -64,7 +64,7 @@ impl Subsystem for StatusMeaning {
                                 .build();
 
                         collector.then(|int| async move {
-                            let mut data = ctx.data.write().await;
+                            let mut data = crate::acquire_data_handle!(write ctx);
                             let config = data.get_mut::<Config>().unwrap();
 
                             let inputs: Vec<_> = int
@@ -106,7 +106,7 @@ impl Subsystem for StatusMeaning {
                 command::PermissionType::Universal,
                 Some(Box::new(move |ctx, command| {
                     Box::pin(async {
-                        let data = ctx.data.read().await;
+                        let data = crate::acquire_data_handle!(read ctx);
                         let config = data.get::<Config>().unwrap();
                         let manager = config.get_manager().to_user(&ctx.http).await?.mention();
                         let resp = match config.get_status_meaning() {

--- a/src/subsystems/stream_indicator.rs
+++ b/src/subsystems/stream_indicator.rs
@@ -20,7 +20,7 @@ impl Subsystem for StreamIndicator {
     }
 
     async fn presence(&self, ctx: &Context, new_data: &Presence) {
-        let data = ctx.data.read().await;
+        let data = crate::acquire_data_handle!(read ctx);
         let config = data.get::<Config>().unwrap();
         if let Some(activity) = new_data
             .activities
@@ -53,7 +53,7 @@ impl Subsystem for StreamIndicator {
                         notify = false;
                     }
                 }
-                drop(data);
+                crate::drop_data_handle!(data);
                 if notify {
                     notify_subscribers(
                         ctx,


### PR DESCRIPTION
An issue was observed where, if the Memes & Nickname Announcements channels were the same, the nickname failure announcement would consistently trigger a deadlock.

The cause of this is not very logical to me, beyond appearing that the waiting write handle from the memes subsystem's New Message handler prevents additional read handles required by the nickname lottery error handling, thereby preventing execution. (Surely the read handles should be allowed to simply execute, not be blocked by the _waiting_ write handle? Is it a queue...? I didn't think it was, but perhaps I'm wrong.)

This addresses the issue in this case by sharing the existing read handle to ensure that the function can finish (and thereby drop the read handle!).