### PR TITLE
Update Serenity to v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,30 +90,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.73"
+name = "arrayvec"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "async-tungstenite"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b71b31561643aa8e7df3effe284fa83ab1a840e52294c5f4bd7bfd8b2becbb"
-dependencies = [
- "futures-io",
- "futures-util",
- "log",
- "pin-project-lite",
- "tokio",
- "tokio-rustls 0.23.4",
- "tungstenite",
- "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -139,15 +132,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
@@ -157,9 +144,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "block-buffer"
@@ -177,6 +164,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
+name = "bytecount"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +180,37 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "cc"
@@ -245,10 +269,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.4"
+name = "core-foundation"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
@@ -269,6 +303,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,7 +334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -293,11 +342,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.3.8"
+name = "data-encoding"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
+ "powerfmt",
  "serde",
 ]
 
@@ -350,10 +406,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "flate2"
-version = "1.0.27"
+name = "errno"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -391,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -405,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -415,21 +496,21 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -438,21 +519,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -464,6 +545,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -494,6 +584,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "h2"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,7 +600,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.9",
  "indexmap 1.9.3",
  "slab",
  "tokio",
@@ -520,9 +616,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hermit-abi"
@@ -542,13 +638,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.9",
  "pin-project-lite",
 ]
 
@@ -581,7 +688,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.9",
  "http-body",
  "httparse",
  "httpdate",
@@ -601,7 +708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.9",
  "hyper",
  "rustls 0.21.7",
  "tokio",
@@ -658,7 +765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -684,9 +791,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -744,6 +857,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mini-moka"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap",
+ "skeptic",
+ "smallvec",
+ "tagptr",
+ "triomphe",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,14 +882,20 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -803,7 +937,7 @@ version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -843,15 +977,6 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "ordered-float"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -902,6 +1027,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,18 +1040,29 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.33"
+name = "pulldown-cmark"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
+dependencies = [
+ "bitflags 2.4.2",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -995,17 +1137,17 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "reqwest"
-version = "0.11.20"
+version = "0.11.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
+checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
 dependencies = [
- "base64 0.21.4",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.9",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -1022,6 +1164,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-util",
@@ -1044,10 +1188,25 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
- "untrusted",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1057,15 +1216,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
-name = "rustls"
-version = "0.20.9"
+name = "rustix"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
+ "bitflags 2.4.2",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1075,9 +1235,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
- "ring",
- "rustls-webpki",
+ "ring 0.16.20",
+ "rustls-webpki 0.101.5",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1086,8 +1260,14 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.4",
+ "base64",
 ]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
 
 [[package]]
 name = "rustls-webpki"
@@ -1095,21 +1275,35 @@ version = "0.101.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.14"
+name = "rustls-webpki"
+version = "0.102.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
+]
 
 [[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1123,34 +1317,43 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1159,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -1191,45 +1394,60 @@ dependencies = [
 
 [[package]]
 name = "serenity"
-version = "0.11.6"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d007dc45584ecc47e791f2a9a7cf17bf98ac386728106f111159c846d624be3f"
+checksum = "c64da29158bb55d70677cacd4f4f8eab1acef005fb830d9c3bea411b090e96a9"
 dependencies = [
+ "arrayvec",
  "async-trait",
- "async-tungstenite",
- "base64 0.13.1",
- "bitflags 1.3.2",
+ "base64",
+ "bitflags 2.4.2",
  "bytes",
- "cfg-if",
  "chrono",
  "dashmap",
  "flate2",
  "futures",
- "mime",
+ "fxhash",
  "mime_guess",
  "parking_lot",
  "percent-encoding",
  "reqwest",
- "rustversion",
+ "secrecy",
  "serde",
- "serde-value",
  "serde_json",
  "time",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "typemap_rev",
+ "typesize",
  "url",
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.1"
+name = "sha1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "skeptic"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
+dependencies = [
+ "bytecount",
+ "cargo_metadata",
+ "error-chain",
+ "glob",
+ "pulldown-cmark",
+ "tempfile",
+ "walkdir",
 ]
 
 [[package]]
@@ -1259,12 +1477,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1274,14 +1492,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "syn"
-version = "2.0.37"
+name = "spin"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "syn"
+version = "2.0.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1306,12 +1581,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.28"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -1319,16 +1596,17 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.14"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -1349,9 +1627,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1359,31 +1637,20 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2 0.5.4",
+ "socket2 0.5.6",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls 0.20.9",
- "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -1394,6 +1661,33 @@ checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls 0.21.7",
  "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.2",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.22.2",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tungstenite",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -1452,11 +1746,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -1465,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1476,12 +1769,18 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "triomphe"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
 
 [[package]]
 name = "try-lock"
@@ -1491,36 +1790,65 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
 dependencies = [
- "base64 0.13.1",
  "byteorder",
  "bytes",
- "http",
+ "data-encoding",
+ "http 1.1.0",
  "httparse",
  "log",
  "rand",
- "rustls 0.20.9",
- "sha-1",
+ "rustls 0.22.2",
+ "rustls-pki-types",
+ "sha1",
  "thiserror",
  "url",
  "utf-8",
- "webpki",
 ]
 
 [[package]]
 name = "typemap_rev"
-version = "0.1.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5b74f0a24b5454580a79abb6994393b09adf0ab8070f15827cb666255de155"
+checksum = "74b08b0c1257381af16a5c3605254d529d3e7e109f3c62befc5d168968192998"
 
 [[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "typesize"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36924509726e38224322c8c90ddfbf4317324338327b7c11b7cf8672cb786da1"
+dependencies = [
+ "chrono",
+ "dashmap",
+ "hashbrown 0.14.3",
+ "mini-moka",
+ "parking_lot",
+ "secrecy",
+ "serde_json",
+ "time",
+ "typesize-derive",
+ "url",
+]
+
+[[package]]
+name = "typesize-derive"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b122284365ba8497be951b9a21491f70c9688eb6fddc582931a0703f6a00ece"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "unicase"
@@ -1565,6 +1893,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,6 +1933,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -1683,9 +2027,9 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-streams"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -1705,29 +2049,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -1744,6 +2078,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1910,3 +2253,9 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ openssl = { version = "^0.10.32", features = ["vendored"] }
 const_format = { version = "0.2.32", optional = true }
 
 [dependencies.serenity]
-version = "^0.11"
+version = "^0.12"
 default-features = false
 features = [
     "builder",

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use log::error;
 
 use serde::{Deserialize, Serialize};
 use serenity::client::{Client, ClientBuilder};
-use serenity::model::prelude::{Channel, GuildId, UserId};
+use serenity::model::prelude::{GuildId, UserId};
 use serenity::prelude::{GatewayIntents, TypeMap, TypeMapKey};
 
 #[cfg(feature = "events")]
@@ -22,6 +22,8 @@ use crate::subsystems::scoreboard::ScoreboardData;
 use crate::subsystems::timeout_monitor::{
     AnnouncementsConfig as TimeoutAnnouncementsConfig, UserTimeoutData,
 };
+#[cfg(feature = "timeout-monitor")]
+use serenity::model::prelude::Channel;
 #[cfg(feature = "memes")]
 use serenity::model::prelude::ChannelId;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,8 +46,8 @@ Whoops! This is _almost certainly_ a development oversight...
 Badger the bot manager about it."
             ),
             Self::SerenityError(e) => match e {
-                serenity::Error::Http(e) => match &**e {
-                    serenity::http::error::Error::UnsuccessfulRequest(resp) => {
+                serenity::Error::Http(e) => match &e {
+                    serenity::all::HttpError::UnsuccessfulRequest(resp) => {
                         if resp.status_code == serenity::http::StatusCode::FORBIDDEN {
                             write!(
                                 f,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,10 @@ mod serenity_handler;
 mod subsystems;
 
 pub use log::{error, info};
+use serenity::all::CacheHttp as _;
 pub use serenity::{
+    model::Colour,
     prelude::{GatewayIntents, Mentionable},
-    utils::Colour,
 };
 
 pub use command::{Command, *};
@@ -79,7 +80,7 @@ start streaming (excluding server owner).";
         features += "\n**•** Randomised, automatic nickname changing.";
     }
     if cfg!(feature = "scoreboard") {
-        features += "\n **•** Scoreboards.";
+        features += "\n**•** Scoreboards.";
     }
 
     features
@@ -106,7 +107,7 @@ fn generate_commands() -> Vec<Command<'static>> {
         "about",
         "Provides information about Loki.",
         command::PermissionType::Universal,
-        Some(Box::new(move |ctx, command| {
+        Some(Box::new(move |ctx, _command, _params| {
             Box::pin(async {
                 let manager_tag = ctx
                     .data
@@ -115,13 +116,11 @@ fn generate_commands() -> Vec<Command<'static>> {
                     .get::<Config>()
                     .unwrap()
                     .get_manager()
-                    .to_user(&ctx.http)
+                    .to_user(&ctx.http())
                     .await?
                     .mention();
-                command::create_response(
-                    &ctx.http,
-                    command,
-                    &format!(
+                Ok(Some(ActionResponse::new(
+                    create_raw_embed(&format!(
                         "Loki is a trickster ~~god~~ bot.
 Version [{VERSION}]({GITHUB_URL}/releases/tag/v{VERSION}); [source code]({GITHUB_URL}).
 
@@ -129,11 +128,9 @@ This instance of Loki is managed by {manager_tag}.
 
 Currently enabled features: {}",
                         features()
-                    ),
+                    )),
                     false,
-                )
-                .await;
-                Ok(())
+                )))
             })
         })),
     )];

--- a/src/serenity_handler.rs
+++ b/src/serenity_handler.rs
@@ -1,18 +1,18 @@
 use crate::command::OptionType;
 use crate::config::Config;
 use crate::subsystems;
-use log::{error, info, trace};
-use serenity::builder::{CreateApplicationCommand, CreateApplicationCommandOption};
+use log::{error, info, trace, warn};
+use serenity::all::{
+    ActivityData, CacheHttp as _, Command, CommandDataOptionValue, CommandOptionType,
+    GuildMemberUpdateEvent, Interaction,
+};
+use serenity::builder::{CreateCommand, CreateCommandOption};
 #[cfg(debug_assertions)]
 use serenity::model::prelude::GuildId;
 use serenity::model::prelude::{GuildChannel, Member};
 use serenity::{
     async_trait,
-    model::prelude::{
-        command::{Command, CommandOptionType},
-        interaction::Interaction,
-        Activity, Guild, Message, Presence, Ready,
-    },
+    model::prelude::{Guild, Message, Presence, Ready},
     prelude::{Context, EventHandler},
 };
 use tokio::task::JoinSet;
@@ -26,70 +26,6 @@ use crate::subsystems::events::Event;
 #[cfg(debug_assertions)]
 const DEBUG_GUILD_ID: &str = env!("LOKI_DEBUG_GUILD_ID");
 
-macro_rules! build_opt {
-    ($opt:ident) => {
-        |option| {
-            option
-                .name($opt.name())
-                .description($opt.description())
-                .kind($opt.kind().into())
-                .required($opt.required());
-            match $opt.kind() {
-                OptionType::StringInput(min, max) => {
-                    if let Some(min) = min {
-                        option.min_length(min);
-                    }
-                    if let Some(max) = max {
-                        option.max_length(max);
-                    }
-                }
-                OptionType::StringSelect(options) => {
-                    options.iter().for_each(|s| {
-                        option.add_string_choice(s, s);
-                    });
-                }
-                OptionType::IntegerInput(min, max) => {
-                    if let Some(min) = min {
-                        option.min_int_value(min);
-                    }
-                    if let Some(max) = max {
-                        option.max_int_value(max);
-                    }
-                }
-                OptionType::IntegerSelect(options) => {
-                    options.iter().for_each(|s| {
-                        option.add_int_choice(s, *s as i32);
-                    });
-                }
-                OptionType::NumberInput(min, max) => {
-                    if let Some(min) = min {
-                        option.min_number_value(min);
-                    }
-                    if let Some(max) = max {
-                        option.max_number_value(max);
-                    }
-                }
-                OptionType::NumberSelect(options) => {
-                    options.iter().for_each(|s| {
-                        option.add_number_choice(s, *s);
-                    });
-                }
-                OptionType::Channel(types) => {
-                    if let Some(types) = types {
-                        option.channel_types(&types);
-                    }
-                }
-                OptionType::Boolean
-                | OptionType::User
-                | OptionType::Role
-                | OptionType::Mentionable
-                | OptionType::Attachment => {}
-            }
-            option
-        }
-    };
-}
-
 /// Core implementation logic for [serenity] events.
 pub struct SerenityHandler<'a> {
     commands: Vec<crate::command::Command<'a>>,
@@ -100,7 +36,7 @@ impl EventHandler for SerenityHandler<'_> {
     async fn ready(&self, ctx: Context, ready: Ready) {
         info!("Loki is connected as {}", ready.user.name);
 
-        ctx.set_activity(Activity::playing("tricks")).await;
+        ctx.set_activity(Some(ActivityData::playing("tricks")));
 
         // creates the global application commands
         self.create_commands(&ctx).await;
@@ -110,8 +46,9 @@ impl EventHandler for SerenityHandler<'_> {
         }
     }
 
-    async fn guild_create(&self, ctx: Context, g: Guild, is_new: bool) {
-        trace!("Guild Creation event for {g:?} (new: {is_new})");
+    async fn guild_create(&self, ctx: Context, g: Guild, is_new: Option<bool>) {
+        info!("Guild Creation event for {} (new: {is_new:?})", g.id);
+        trace!("Guild Creation data: {g:?}");
         let mut data = crate::acquire_data_handle!(write ctx);
         let config = data.get_mut::<Config>().unwrap();
         let guild = config.guild_mut(&g.id);
@@ -157,40 +94,62 @@ impl EventHandler for SerenityHandler<'_> {
 
     async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
         trace!("Handling Interaction: {:?}", interaction);
-        if let Interaction::ApplicationCommand(mut command) = interaction {
+        if let Interaction::Command(mut command) = interaction {
             for cmd in self.commands.iter() {
                 if cmd.name() == command.data.name {
                     let mut cmd = cmd;
+                    let mut options = command.data.options.clone();
                     if !command.data.options.is_empty()
-                        && command.data.options[0].kind == CommandOptionType::SubCommand
+                        && command.data.options[0].kind() == CommandOptionType::SubCommand
                     {
                         for subcmd in cmd.variants() {
                             if subcmd.name() == command.data.options[0].name {
                                 cmd = subcmd;
+                                if let CommandDataOptionValue::SubCommand(os) =
+                                    &command.data.options[0].value
+                                {
+                                    options = os.clone();
+                                } else {
+                                    error!("Failed to extract subcommand options from {command:?}");
+                                }
                                 break;
                             }
                         }
                     };
-                    if let Err(e) = cmd.run(&ctx, &mut command).await {
-                        error!("Error running '{}': {e:?}", cmd.name());
-                        #[cfg(feature = "events")]
-                        notify_subscribers(
-                            &ctx,
-                            Event::Error,
-                            &format!(
-                                "**Error running '{}':**
+                    match cmd.run(&ctx, &mut command, &options).await {
+                        Ok(e) => {
+                            if let Some(e) = e {
+                                let ephemeral = e.ephemeral();
+                                crate::command::create_response_from_embed(
+                                    &ctx.http,
+                                    &mut command,
+                                    e.embed(),
+                                    ephemeral,
+                                )
+                                .await;
+                            }
+                        }
+                        Err(e) => {
+                            error!("Error running '{}': {e:?}", cmd.name());
+                            #[cfg(feature = "events")]
+                            notify_subscribers(
+                                &ctx,
+                                Event::Error,
+                                &format!(
+                                    "**Error running '{}':**
 {e}",
-                                cmd.name()
-                            ),
-                        )
-                        .await;
-                        crate::command::create_response(
-                            &ctx.http,
-                            &mut command,
-                            &format!("{e}"),
-                            false,
-                        )
-                        .await;
+                                    cmd.name()
+                                ),
+                            )
+                            .await;
+                            crate::command::create_response(
+                                &ctx.http,
+                                &mut command,
+                                &format!("{e}"),
+                                false,
+                            )
+                            .await;
+                        }
                     }
                     break;
                 }
@@ -212,41 +171,107 @@ impl EventHandler for SerenityHandler<'_> {
         }
     }
 
-    async fn thread_update(&self, ctx: Context, thread: GuildChannel) {
+    async fn thread_update(&self, ctx: Context, _old: Option<GuildChannel>, thread: GuildChannel) {
         trace!("Handling Thread update: {:?}", thread);
         for s in subsystems() {
             s.thread(&ctx, &thread).await;
         }
     }
 
-    async fn guild_member_update(&self, ctx: Context, old: Option<Member>, new: Member) {
+    async fn guild_member_update(
+        &self,
+        ctx: Context,
+        old: Option<Member>,
+        new: Option<Member>,
+        event: GuildMemberUpdateEvent,
+    ) {
         trace!("Handling Guild Member update: {:?} --> {:?}", old, new);
-        for s in subsystems() {
-            s.member(&ctx, &old, &new).await;
+        if let Some(new) = new {
+            for s in subsystems() {
+                s.member(&ctx, &old, &new).await;
+            }
+        } else {
+            warn!("No new data when handling Guild Member update: {old:?} --> {new:?} ({event:?})");
         }
     }
 }
 
-pub fn construct_command(
-    cmd: crate::command::Command,
-) -> impl FnOnce(&mut CreateApplicationCommand) -> &mut CreateApplicationCommand + '_ {
-    move |command: &mut CreateApplicationCommand| {
-        let mut command = command
-            .name(cmd.name())
-            .description(cmd.description())
-            .dm_permission(*cmd.permissions() == crate::command::PermissionType::Universal);
-        if let crate::command::PermissionType::ServerPerms(permissions) = *cmd.permissions() {
-            command = command.default_member_permissions(permissions);
-        }
-        for variant in cmd.variants() {
-            command = command
-                .create_option(|subcmd| crate::SerenityHandler::create_variant(subcmd, variant))
-        }
-        for opt in cmd.options() {
-            command = command.create_option(build_opt!(opt))
-        }
-        command
+pub fn construct_command(cmd: &crate::command::Command) -> CreateCommand {
+    let mut command = CreateCommand::new(cmd.name())
+        .description(cmd.description())
+        .dm_permission(*cmd.permissions() == crate::command::PermissionType::Universal);
+    if let crate::command::PermissionType::ServerPerms(permissions) = *cmd.permissions() {
+        command = command.default_member_permissions(permissions);
     }
+    for variant in cmd.variants() {
+        command = command.add_option(crate::SerenityHandler::create_variant(variant))
+    }
+    for opt in cmd.options() {
+        command = command.add_option(construct_option(opt))
+    }
+    command
+}
+
+pub fn construct_option(opt: &crate::command::Option) -> CreateCommandOption {
+    let mut option = CreateCommandOption::new(opt.kind().into(), opt.name(), opt.description())
+        .required(opt.required());
+    match opt.kind() {
+        OptionType::StringInput(min, max) => {
+            if let Some(min) = min {
+                option = option.clone().min_length(min);
+            }
+            if let Some(max) = max {
+                option = option.clone().max_length(max);
+            }
+        }
+        OptionType::StringSelect(options) => {
+            options.iter().for_each(|s| {
+                option = option.clone().add_string_choice(s, s);
+            });
+        }
+        OptionType::IntegerInput(min, max) => {
+            // Note: The `try_into.unwrap` portion is included to work around a bug introduced by Serenity 0.12; once that bug is fixed (which will in turn make these lines break!), remove these.
+            if let Some(min) = min {
+                option = option
+                    .clone()
+                    .min_int_value(min.try_into().unwrap_or(u64::MIN));
+            }
+            if let Some(max) = max {
+                option = option
+                    .clone()
+                    .max_int_value(max.try_into().unwrap_or(u64::MAX));
+            }
+        }
+        OptionType::IntegerSelect(options) => {
+            options.iter().for_each(|s| {
+                option = option.clone().add_int_choice(s.to_string(), *s as i32);
+            });
+        }
+        OptionType::NumberInput(min, max) => {
+            if let Some(min) = min {
+                option = option.clone().min_number_value(min);
+            }
+            if let Some(max) = max {
+                option = option.clone().max_number_value(max);
+            }
+        }
+        OptionType::NumberSelect(options) => {
+            options.iter().for_each(|s| {
+                option = option.clone().add_number_choice(s.to_string(), *s);
+            });
+        }
+        OptionType::Channel(types) => {
+            if let Some(types) = types {
+                option = option.clone().channel_types(types);
+            }
+        }
+        OptionType::Boolean
+        | OptionType::User
+        | OptionType::Role
+        | OptionType::Mentionable
+        | OptionType::Attachment => {}
+    }
+    option
 }
 
 impl<'a> SerenityHandler<'a> {
@@ -255,15 +280,13 @@ impl<'a> SerenityHandler<'a> {
         Self { commands }
     }
 
-    pub(crate) fn create_variant<'b>(
-        subcmd: &'b mut CreateApplicationCommandOption,
-        variant: &crate::Command,
-    ) -> &'b mut CreateApplicationCommandOption {
-        let mut subcmd = subcmd
-            .name(variant.name())
-            .description(variant.description())
-            .kind(CommandOptionType::SubCommand)
-            .required(false);
+    pub(crate) fn create_variant<'b>(variant: &crate::Command) -> CreateCommandOption {
+        let mut subcmd = CreateCommandOption::new(
+            CommandOptionType::SubCommand,
+            variant.name(),
+            variant.description(),
+        )
+        .required(false);
         assert!(
             variant.variants().is_empty(),
             "Discord does not currently support nesting CommandGroups."
@@ -272,42 +295,37 @@ impl<'a> SerenityHandler<'a> {
         //     subcmd = subcmd.create_sub_option(|subcmd| Self::create_variant(subcmd, variant));
         // }
         for opt in variant.options() {
-            subcmd = subcmd.create_sub_option(build_opt!(opt))
+            subcmd = subcmd.add_sub_option(construct_option(opt))
         }
         subcmd
     }
 
     async fn create_commands(&self, ctx: &Context) -> Vec<Command> {
-        macro_rules! commands_constructor {
-            () => {
-                |mut commands| {
-                    for cmd in self.commands.iter().filter(|cmd| cmd.global()) {
-                        commands =
-                            commands.create_application_command(construct_command(cmd.clone()))
-                    }
-                    commands
-                }
-            };
-        }
+        let commands = self
+            .commands
+            .iter()
+            .filter(|cmd| cmd.global())
+            .map(construct_command)
+            .collect::<Vec<CreateCommand>>();
         #[cfg(debug_assertions)]
         {
-            let guild = GuildId(DEBUG_GUILD_ID.parse::<u64>().unwrap_or_else(|_| {
+            let guild = GuildId::new(DEBUG_GUILD_ID.parse::<u64>().unwrap_or_else(|_| {
                 panic!(
                     "{}",
                     ("Couldn't parse 'LOKI_DEBUG_GUILD_ID' as a u64: ".to_owned() + DEBUG_GUILD_ID)
                 )
             }))
-            .to_partial_guild(&ctx.http)
+            .to_partial_guild(&ctx.http())
             .await
             .unwrap();
             guild
-                .set_application_commands(&ctx.http, commands_constructor!())
+                .set_commands(&ctx.http, commands)
                 .await
                 .expect("Failed to create command")
         }
         #[cfg(not(debug_assertions))]
         {
-            Command::set_global_application_commands(&ctx.http, commands_constructor!())
+            Command::set_global_commands(&ctx.http(), commands)
                 .await
                 .expect("Failed to create command")
         }

--- a/src/subsystems/mod.rs
+++ b/src/subsystems/mod.rs
@@ -6,6 +6,18 @@ use serenity::{
 
 use crate::command::Command;
 
+macro_rules! get_param {
+    ($params:ident, $variant:ident, $name:expr) => {
+        if let serenity::all::CommandDataOptionValue::$variant(s) =
+            &$params.iter().find(|opt| opt.name == $name).unwrap().value
+        {
+            s
+        } else {
+            return Err(crate::Error::InvalidParam($name.to_string()));
+        }
+    };
+}
+
 #[cfg(feature = "events")]
 pub mod events;
 #[cfg(feature = "memes")]

--- a/src/subsystems/nickname_lottery.rs
+++ b/src/subsystems/nickname_lottery.rs
@@ -8,15 +8,9 @@ use rand::{
 };
 use serde::{Deserialize, Serialize};
 use serenity::{
+    all::{CacheHttp as _, CommandDataOptionValue, CreateModal, Guild, Mentionable as _, UserId},
     async_trait,
-    futures::StreamExt,
-    model::{
-        channel::ChannelType,
-        id::ChannelId,
-        mention::Mentionable,
-        prelude::{interaction::application_command::CommandDataOptionValue, Guild, UserId},
-        Permissions,
-    },
+    model::{channel::ChannelType, id::ChannelId, Permissions},
     prelude::Context,
 };
 
@@ -24,8 +18,8 @@ use serenity::{
 use crate::{command::notify_subscribers, subsystems::events::Event};
 
 use crate::{
-    command::OptionType, config::Config, create_embed, create_response,
-    notify_subscribers_with_handle,
+    command::OptionType, config::Config, create_embed, create_raw_embed,
+    notify_subscribers_with_handle, ActionResponse,
 };
 use crate::{
     command::{Command, PermissionType},
@@ -34,7 +28,7 @@ use crate::{
 
 use super::Subsystem;
 
-// (30 mins, 5 days) in seconds.
+/// (30 mins, 5 days) in seconds.
 const REFRESH_INTERVAL: (u64, u64) = (1_800, 432_000);
 
 #[derive(Default)]
@@ -103,7 +97,7 @@ impl NicknameLotteryGuildData {
         self.user_specific_nicknames
             .keys()
             .choose(&mut rand::thread_rng())
-            .map(|id| UserId(u64::from_str(id).unwrap()))
+            .map(|id| UserId::new(u64::from_str(id).unwrap()))
     }
 
     /// Set the complaints channel.
@@ -134,179 +128,192 @@ impl NicknameLotteryGuildData {
 #[async_trait]
 impl Subsystem for NicknameLottery {
     fn generate_commands(&self) -> Vec<Command<'static>> {
-        vec![
+        vec![Command::new(
+            "nickname_lottery",
+            "Controls for the nickname lottery.",
+            PermissionType::ServerPerms(Permissions::MANAGE_NICKNAMES),
+            None,
+        )
+        .add_variant(
             Command::new(
-                "nickname_lottery",
-                "Controls for the nickname lottery.",
+                "set_nicknames",
+                "Set the list of nicknames that can be applied to a specific user.",
                 PermissionType::ServerPerms(Permissions::MANAGE_NICKNAMES),
-                None,
-            )
-            .add_variant(
-                Command::new(
-                    "set_nicknames",
-                    "Set the list of nicknames that can be applied to a specific user.",
-                    PermissionType::ServerPerms(Permissions::MANAGE_NICKNAMES),
-                    Some(Box::new(move |ctx, command| {
-                        Box::pin(async move {
-                            let user = command.data.options[0].options.iter().find(|opt| opt.name == "user").and_then(|u| {
-                                if let Some(CommandDataOptionValue::User(user, _)) = &u.resolved {
-                                    Some(user.clone())
-                                } else {
-                                    None
-                                }
-                            }).unwrap();
-                            let guild_id = command.guild_id.unwrap();
+                Some(Box::new(move |ctx, command, params| {
+                    Box::pin(async move {
+                        let user = get_param!(params, User, "user");
+                        let user = command.data.resolved.users.get(&user).unwrap();
+                        let guild_id = command.guild_id.unwrap();
 
-                            let data = crate::acquire_data_handle!(read ctx);
-                            let guild = get_guild(&data, &guild_id).unwrap();
-                            let nickname_lottery_data = guild.nickname_lottery_data();
+                        let data = crate::acquire_data_handle!(read ctx);
+                        let guild = get_guild(&data, &guild_id).unwrap();
+                        let nickname_lottery_data = guild.nickname_lottery_data();
 
-                            let old_nicknames = nickname_lottery_data.user_nicknames_string(&user.id);
+                        info!(
+                            "[Guild: {}] Updating nickname list for {} ({})",
+                            guild_id, user.name, user.id
+                        );
 
-                            let mut input_nicks = serenity::builder::CreateInputText::default();
-                            input_nicks
-                                .label("Nicknames list")
-                                .custom_id("nicknames_list")
-                                .style(serenity::model::prelude::component::InputTextStyle::Paragraph)
-                                .placeholder("List of nicknames, each on a new line (or blank to unset).")
-                                .required(false)
-                                .value(old_nicknames);
-                            crate::drop_data_handle!(data);
+                        let old_nicknames = nickname_lottery_data.user_nicknames_string(&user.id);
 
-                            let mut components = serenity::builder::CreateComponents::default();
-                            components.create_action_row(|r| r.add_input_text(input_nicks));
+                        let input_nicks = serenity::builder::CreateInputText::new(
+                            serenity::all::InputTextStyle::Paragraph,
+                            "Nicknames list",
+                            "nicknames_list",
+                        )
+                        .placeholder("List of nicknames, each on a new line (or blank to unset).")
+                        .required(false)
+                        .value(old_nicknames);
+                        crate::drop_data_handle!(data);
 
-                            command
-                                .create_interaction_response(&ctx.http, |r| {
-                                    r.kind(
-                                        serenity::model::application::interaction::InteractionResponseType::Modal,
-                                    );
-                                    r.interaction_response_data(|d| {
-                                        d.title(format!("{}'s nicknames",
-                                            user.name
-                                        ))
-                                        .custom_id(user.id.to_string() + "_set_nicknames")
-                                        .set_components(components)
-                                    })
-                                })
-                                .await?;
+                        let components =
+                            vec![serenity::all::CreateActionRow::InputText(input_nicks)];
 
-                            let userid = user.id;
-                            // collect the submitted data
-                            let collector =
-                                serenity::collector::ModalInteractionCollectorBuilder::new(ctx)
-                                    .filter(move |int| int.data.custom_id == userid.to_string() + "_set_nicknames")
-                                    .collect_limit(1)
-                                    .build();
+                        command
+                            .create_response(
+                                &ctx.http(),
+                                serenity::all::CreateInteractionResponse::Modal(
+                                    CreateModal::new(
+                                        user.id.to_string() + "_set_nicknames",
+                                        format!("{}'s nicknames", user.name),
+                                    )
+                                    .components(components),
+                                ),
+                            )
+                            .await?;
 
-                            collector.then(|int| async move {
-                                let mut data = crate::acquire_data_handle!(write ctx);
-                                let config = data.get_mut::<Config>().unwrap();
-                                let guild = config.guild_mut(&guild_id.clone());
-                                let nickname_lottery_data = guild.nickname_lottery_data_mut();
+                        let userid = user.id;
+                        // collect the submitted data
+                        if let Some(int) = serenity::collector::ModalInteractionCollector::new(ctx)
+                            .filter(move |int| {
+                                int.data.custom_id == userid.to_string() + "_set_nicknames"
+                            })
+                            .timeout(Duration::new(300, 0))
+                            .await
+                        {
+                            let mut data = crate::acquire_data_handle!(write ctx);
+                            let config = data.get_mut::<Config>().unwrap();
+                            let guild = config.guild_mut(&guild_id.clone());
+                            let nickname_lottery_data = guild.nickname_lottery_data_mut();
 
-                                let inputs: Vec<_> = int
-                                    .data
-                                    .components
-                                    .iter()
-                                    .flat_map(|r| r.components.iter())
-                                    .collect();
+                            let inputs: Vec<_> = int
+                                .data
+                                .components
+                                .iter()
+                                .flat_map(|r| r.components.iter())
+                                .collect();
 
-                                for input in inputs.iter() {
-                                    if let serenity::model::prelude::component::ActionRowComponent::InputText(it) = input {
-                                        if it.custom_id == "nicknames_list" {
-                                                nickname_lottery_data.set_user_nicknames(&user.id, &NicknameLotteryGuildData::deconstruct_nickname_string(&it.value.clone()).iter().map(|n| n.as_str()).collect::<Vec<&str>>());
+                            for input in inputs.iter() {
+                                if let serenity::all::ActionRowComponent::InputText(it) = input {
+                                    if it.custom_id == "nicknames_list" {
+                                        if let Some(it) = &it.value {
+                                            nickname_lottery_data.set_user_nicknames(
+                                            &user.id,
+                                            &NicknameLotteryGuildData::deconstruct_nickname_string(
+                                                &it.clone(),
+                                            )
+                                            .iter()
+                                            .map(|n| n.as_str())
+                                            .collect::<Vec<&str>>(),
+                                        );
                                         }
                                     }
                                 }
+                            }
 
-                                config.save();
+                            config.save();
 
-                                // it's now safe to close the modal, so send a response to it
-                                int.create_interaction_response(&ctx.http, |r| {
-                                    r.kind(serenity::model::prelude::interaction::InteractionResponseType::DeferredUpdateMessage)
-                                })
-                                .await
-                                .ok();
-                            })
-                            .collect::<Vec<_>>()
-                            .await;
+                            // it's now safe to close the modal, so send a response to it
+                            int.create_response(
+                                &ctx.http(),
+                                serenity::all::CreateInteractionResponse::Acknowledge,
+                            )
+                            .await?;
+                        }
 
-                            Ok(())
-                        })
-                    })),
-                )
-                .add_option(
-                    crate::Option::new(
-                        "user",
-                        "The user to set the nickname list for.",
-                        OptionType::User,
-                        true
-                    )
-                ),
+                        Ok(None)
+                    })
+                })),
             )
-            .add_variant(Command::new(
-            "configure_announcements",
-            "Configure announcements when the bot fails to change a user's nickname.",
-            PermissionType::ServerPerms(Permissions::MANAGE_CHANNELS),
-            Some(Box::new(move |ctx, command| {
-                Box::pin(async {
-                    // Set announcement channel if it's been supplied.
-                    if let Some(channel_opt) = command.data.options[0].options.iter().find(|opt| opt.name == "channel") {
-                        let mut data = crate::acquire_data_handle!(write ctx);
-                        let config = data.get_mut::<Config>().unwrap();
-                        let guild = config.guild_mut(&command.guild_id.unwrap());
-                        if let Some(CommandDataOptionValue::Channel(channel)) = &channel_opt.resolved {
-                            let channel = channel.id.to_channel(&ctx.http).await?;
-                            guild.nickname_lottery_data_mut().set_complaints_channel(Some(channel.id()));
-                            config.save();
-                        }
-                    };
+            .add_option(crate::Option::new(
+                "user",
+                "The user to set the nickname list for.",
+                OptionType::User,
+                true,
+            )),
+        )
+        .add_variant(
+            Command::new(
+                "configure_announcements",
+                "Configure announcements when the bot fails to change a user's nickname.",
+                PermissionType::ServerPerms(Permissions::MANAGE_CHANNELS),
+                Some(Box::new(move |ctx, command, params| {
+                    Box::pin(async {
+                        // Set announcement channel if it's been supplied.
+                        if let Some(channel_opt) = params.iter().find(|opt| opt.name == "channel") {
+                            let mut data = crate::acquire_data_handle!(write ctx);
+                            let config = data.get_mut::<Config>().unwrap();
+                            let guild = config.guild_mut(&command.guild_id.unwrap());
+                            if let CommandDataOptionValue::Channel(channel) = &channel_opt.value {
+                                let channel = channel.to_channel(&ctx.http()).await?;
+                                guild
+                                    .nickname_lottery_data_mut()
+                                    .set_complaints_channel(Some(channel.id()));
+                                config.save();
+                            }
+                        };
 
+                        // Set title override if it's been supplied.
+                        if let Some(title_opt) =
+                            params.iter().find(|opt| opt.name == "title_override")
+                        {
+                            let mut data = crate::acquire_data_handle!(write ctx);
+                            let config = data.get_mut::<Config>().unwrap();
+                            let guild = config.guild_mut(&command.guild_id.unwrap());
+                            let lottery_data = guild.nickname_lottery_data_mut();
+                            if let CommandDataOptionValue::String(title_override) = &title_opt.value
+                            {
+                                lottery_data.set_title_override(Some(title_override.to_owned()));
+                                config.save();
+                            }
+                        };
 
-                    // Set title override if it's been supplied.
-                    if let Some(title_opt) = command.data.options[0].options.iter().find(|opt| opt.name == "title_override") {
-                        let mut data = crate::acquire_data_handle!(write ctx);
-                        let config = data.get_mut::<Config>().unwrap();
-                        let guild = config.guild_mut(&command.guild_id.unwrap());
-                        let lottery_data = guild.nickname_lottery_data_mut();
-                        if let Some(CommandDataOptionValue::String(title_override)) = &title_opt.resolved {
-                            lottery_data.set_title_override(Some(title_override.to_owned()));
-                            config.save();
-                        }
-                    };
-
-
-                    let data = crate::acquire_data_handle!(read ctx);
-                    let guild = get_guild(&data, &command.guild_id.unwrap());
-                    let lottery_data = &guild.unwrap().nickname_lottery_data();
-                    let resp = format!("**Nickname lottery complaints channel updated!**
+                        let data = crate::acquire_data_handle!(read ctx);
+                        let guild = get_guild(&data, &command.guild_id.unwrap());
+                        let lottery_data = &guild.unwrap().nickname_lottery_data();
+                        let resp = format!(
+                            "**Nickname lottery complaints channel updated!**
 Channel: {}
 Title text: {}",
-                        lottery_data.complaints_channel().unwrap().to_channel(&ctx.http).await?,
-                        lottery_data.title());
-                    create_response(&ctx.http, command, &resp, true).await;
-                    Ok(())
-                })
-            })),
+                            lottery_data
+                                .complaints_channel()
+                                .unwrap()
+                                .to_channel(&ctx.http())
+                                .await?,
+                            lottery_data.title()
+                        );
+                        Ok(Some(ActionResponse::new(create_raw_embed(&resp), true)))
+                    })
+                })),
+            )
+            .add_option(crate::command::Option::new(
+                "channel",
+                "The channel to announce timeouts in.",
+                OptionType::Channel(Some(vec![ChannelType::Text])),
+                false,
+            ))
+            .add_option(crate::command::Option::new(
+                "title_override",
+                "Text to prepend before the timeout counter message.",
+                OptionType::StringInput(None, None),
+                false,
+            )),
         )
-        .add_option(crate::command::Option::new(
-            "channel",
-            "The channel to announce timeouts in.",
-            OptionType::Channel(Some(vec![ChannelType::Text])),
-            false,
-        ))
-        .add_option(crate::command::Option::new(
-            "title_override",
-            "Text to prepend before the timeout counter message.",
-            OptionType::StringInput(None, None),
-            false,
-        )))
         .add_variant(Command::new(
             "stop_announcements",
             "Stop all announcements. Unsets all configuration values.",
             PermissionType::ServerPerms(Permissions::MANAGE_CHANNELS),
-            Some(Box::new(move |ctx, command| {
+            Some(Box::new(move |ctx, command, _params| {
                 Box::pin(async {
                     let mut data = crate::acquire_data_handle!(write ctx);
                     let config = data.get_mut::<Config>().unwrap();
@@ -317,12 +324,13 @@ Title text: {}",
                     config.save();
                     crate::drop_data_handle!(data);
 
-                    create_response(&ctx.http, command, &"Announcements have been uninitialised.".into(), true).await;
-                    Ok(())
+                    Ok(Some(ActionResponse::new(
+                        create_raw_embed("Announcements have been uninitialised."),
+                        true,
+                    )))
                 })
             })),
-        ))
-        ]
+        ))]
     }
 }
 
@@ -405,7 +413,7 @@ _Nickname changes are disabled for this guild until next initialisation._",
             if let Some(guild) = get_guild(&data, &g.id) {
                 let lottery_data = guild.nickname_lottery_data();
                 if let Some(user) = lottery_data.get_random_user() {
-                    if let Ok(member) = g.member(&ctx.http, user).await {
+                    if let Ok(member) = g.member(&ctx.http(), user).await {
                         let user = &member.user;
                         if let Some(mut new_nick) = lottery_data.get_nickname_for_user(&user.id) {
                             let old_nick = member.display_name();
@@ -423,18 +431,22 @@ _Nickname changes are disabled for this guild until next initialisation._",
                                 &g.id, &user.id, &new_nick, &old_nick
                             );
                             if let Err(e) = g
-                                .edit_member(&ctx.http, user.id, |m| m.nickname(&new_nick))
+                                .edit_member(
+                                    &ctx.http(),
+                                    user.id,
+                                    serenity::all::EditMember::new().nickname(&new_nick),
+                                )
                                 .await
                             {
                                 if let Some(channel_id) = lottery_data.complaints_channel() {
-                                    let channel = match channel_id.to_channel(&ctx.http).await {
+                                    let channel = match channel_id.to_channel(&ctx.http()).await {
                                         Ok(channel) => channel.guild(),
                                         Err(_) => None,
                                     };
                                     if let Some(channel) = channel {
                                         channel
                                             .send_message(
-                                                &ctx.http,
+                                                &ctx.http(),
                                                 create_embed(format!(
                                                     "**{}**
 {} won/lost the lottery! From now on, they are to be named: `{}`",

--- a/src/subsystems/scoreboard.rs
+++ b/src/subsystems/scoreboard.rs
@@ -4,22 +4,22 @@ use const_format::formatcp;
 use log::{error, info, trace};
 use serde::{Deserialize, Serialize};
 use serenity::{
+    all::{CacheHttp as _, Mentionable as _},
     async_trait, futures,
     model::{
         gateway::Ready,
         guild::Guild,
         id::{CommandId, GuildId, UserId},
-        prelude::interaction::application_command::CommandDataOptionValue,
         Permissions,
     },
-    prelude::{Context, Mentionable},
+    prelude::Context,
 };
 use tinyvec::ArrayVec;
 
 use crate::{
-    command::{create_response, Command, OptionType, PermissionType},
+    command::{Command, OptionType, PermissionType},
     config::{get_guild, Config},
-    create_raw_embed, create_response_from_embed, NUM_SELECTABLES,
+    create_raw_embed, ActionResponse, NUM_SELECTABLES,
 };
 #[cfg(feature = "events")]
 use crate::{notify_subscribers, subsystems::events::Event};
@@ -84,7 +84,7 @@ impl ScoreboardData {
         if self.scoreboards.is_empty() {
             if let Some(cid) = self.ephemeral_command_id {
                 self.ephemeral_command_id = None;
-                g.delete_application_command(&ctx.http, cid).await?;
+                g.delete_command(&ctx.http(), cid).await?;
                 info!(
                     "[Guild: {}] Deleted ephemeral `scoreboard` command (id {cid})",
                     g
@@ -110,7 +110,7 @@ impl ScoreboardData {
         let command = Command::new(
             "scoreboard",
             "Track all the scores!",
-            PermissionType::ServerPerms(Permissions::USE_SLASH_COMMANDS),
+            PermissionType::ServerPerms(Permissions::USE_APPLICATION_COMMANDS),
             None,
         )
         .add_variant(
@@ -126,7 +126,7 @@ impl ScoreboardData {
             Command::new(
                 "view",
                 "View the top 10 scores on the board, or a given user's score.",
-                PermissionType::ServerPerms(Permissions::USE_SLASH_COMMANDS),
+                PermissionType::ServerPerms(Permissions::USE_APPLICATION_COMMANDS),
                 None,
             )
             .add_option(scoreboard_select.clone())
@@ -141,7 +141,7 @@ impl ScoreboardData {
             Command::new(
                 "set",
                 "Set your score on a board.",
-                PermissionType::ServerPerms(Permissions::USE_SLASH_COMMANDS),
+                PermissionType::ServerPerms(Permissions::USE_APPLICATION_COMMANDS),
                 None,
             )
             .add_option(scoreboard_select.clone())
@@ -174,9 +174,9 @@ impl ScoreboardData {
             )),
         );
         self.ephemeral_command_id = Some(
-            g.create_application_command(
-                &ctx.http,
-                crate::serenity_handler::construct_command(command),
+            g.create_command(
+                &ctx.http(),
+                crate::serenity_handler::construct_command(&command),
             )
             .await?
             .id,
@@ -257,15 +257,9 @@ impl Subsystem for Scoreboards {
                 "create_scoreboard",
                 formatcp!("Create a new scoreboard (max. {NUM_SCOREBOARDS})."),
                 PermissionType::ServerPerms(Permissions::ADMINISTRATOR),
-                Some(Box::new(move |ctx, command| {
+                Some(Box::new(move |ctx, command, params| {
                     Box::pin(async {
-                        let name = if let Some(CommandDataOptionValue::String(name)) =
-                            &command.data.options[0].resolved
-                        {
-                            name
-                        } else {
-                            return Err(crate::Error::InvalidParam("scoreboard name".to_string()));
-                        };
+                        let name = get_param!(params, String, "name");
                         let mut data = crate::acquire_data_handle!(write ctx);
                         let config = data.get_mut::<Config>().unwrap();
                         let guild = config.guild_mut(&command.guild_id.unwrap());
@@ -276,15 +270,14 @@ impl Subsystem for Scoreboards {
                         {
                             format!(
                                 "**Could not create scoreboard `{name}`:**
-{e}"
+        {e}"
                             )
                         } else {
                             config.save();
                             format!("**Created new scoreboard `{name}`!**")
                         };
                         crate::drop_data_handle!(data);
-                        create_response(&ctx.http, command, &resp, false).await;
-                        Ok(())
+                        Ok(Some(ActionResponse::new(create_raw_embed(&resp), false)))
                     })
                 })),
             )
@@ -297,17 +290,9 @@ impl Subsystem for Scoreboards {
             Command::new_stub("scoreboard", None)
                 .add_variant(Command::new_stub(
                     "delete",
-                    Some(Box::new(move |ctx, command| {
+                    Some(Box::new(move |ctx, command, params| {
                         Box::pin(async {
-                            let name = if let Some(CommandDataOptionValue::String(name)) =
-                                &command.data.options[0].options[0].resolved
-                            {
-                                name
-                            } else {
-                                return Err(crate::Error::InvalidParam(
-                                    "scoreboard name".to_string(),
-                                ));
-                            };
+                            let name = get_param!(params, String, "name");
                             let mut data = crate::acquire_data_handle!(write ctx);
                             let config = data.get_mut::<Config>().unwrap();
                             let guild = config.guild_mut(&command.guild_id.unwrap());
@@ -318,25 +303,15 @@ impl Subsystem for Scoreboards {
                             config.save();
                             crate::drop_data_handle!(data);
                             let resp = format!("**Deleted scoreboard `{name}`.**");
-                            create_response(&ctx.http, command, &resp, false).await;
-                            Ok(())
+                            Ok(Some(ActionResponse::new(create_raw_embed(&resp), false)))
                         })
                     })),
                 ))
                 .add_variant(Command::new_stub(
                     "view",
-                    Some(Box::new(move |ctx, command| {
+                    Some(Box::new(move |ctx, command, params| {
                         Box::pin(async {
-                            let name = if let Some(CommandDataOptionValue::String(name)) =
-                                &command.data.options[0].options[0].resolved
-                            {
-                                name.clone()
-                            } else {
-                                return Err(crate::Error::InvalidParam(
-                                    "scoreboard name".to_string(),
-                                ));
-                            };
-                            let mut resp = create_raw_embed(format!("**{name}**"));
+                            let name = get_param!(params, String, "name");
                             let mut positions = String::new();
                             let mut users = String::new();
                             let mut scores = String::new();
@@ -347,17 +322,13 @@ impl Subsystem for Scoreboards {
                                         "Scoreboard {name} does not exist!"
                                     )),
                                 )?;
-                                if command.data.options[0].options.len() > 1 {
-                                    if let Some(CommandDataOptionValue::User(user, _)) =
-                                        &command.data.options[0].options[1].resolved
-                                    {
-                                        if let Some((p, _, s)) = scoreboard.score(&user.id) {
-                                            positions = p.to_string();
-                                            users = user.mention().to_string();
-                                            scores = s.to_string();
-                                        }
-                                    } else {
-                                        return Err(crate::Error::InvalidParam("user".to_string()));
+                                if params.len() > 1 {
+                                    let user = get_param!(params, User, "user");
+                                    let user = command.data.resolved.users.get(&user).unwrap();
+                                    if let Some((p, _, s)) = scoreboard.score(&user.id) {
+                                        positions = p.to_string();
+                                        users = user.mention().to_string();
+                                        scores = s.to_string();
                                     }
                                 } else {
                                     let entries = scoreboard.scores();
@@ -369,7 +340,10 @@ impl Subsystem for Scoreboards {
                                     users = futures::future::try_join_all(entries.iter().map(
                                         |(_, uid, _)| async {
                                             Ok::<String, crate::Error>(
-                                                uid.to_user(&ctx.http).await?.mention().to_string(),
+                                                uid.to_user(&ctx.http())
+                                                    .await?
+                                                    .mention()
+                                                    .to_string(),
                                             )
                                         },
                                     ))
@@ -382,34 +356,20 @@ impl Subsystem for Scoreboards {
                                         .join("\n");
                                 }
                             }
-                            resp.field("#", positions, true)
+                            let resp = create_raw_embed(format!("**{name}**"))
+                                .field("#", positions, true)
                                 .field("User", users, true)
                                 .field("Score", scores, true);
-                            create_response_from_embed(&ctx.http, command, resp, false).await;
-                            Ok(())
+                            Ok(Some(ActionResponse::new(resp, false)))
                         })
                     })),
                 ))
                 .add_variant(Command::new_stub(
                     "set",
-                    Some(Box::new(move |ctx, command| {
+                    Some(Box::new(move |ctx, command, params| {
                         Box::pin(async {
-                            let name = if let Some(CommandDataOptionValue::String(name)) =
-                                &command.data.options[0].options[0].resolved
-                            {
-                                name
-                            } else {
-                                return Err(crate::Error::InvalidParam(
-                                    "scoreboard name".to_string(),
-                                ));
-                            };
-                            let score = if let Some(CommandDataOptionValue::Integer(score)) =
-                                command.data.options[0].options[1].resolved
-                            {
-                                score
-                            } else {
-                                return Err(crate::Error::InvalidParam("score".to_string()));
-                            };
+                            let name = get_param!(params, String, "name");
+                            let score = *get_param!(params, Integer, "score");
                             let mut data = crate::acquire_data_handle!(write ctx);
                             let config = data.get_mut::<Config>().unwrap();
                             let guild = config.guild_mut(&command.guild_id.unwrap());
@@ -422,7 +382,7 @@ impl Subsystem for Scoreboards {
                             crate::drop_data_handle!(data);
                             let resp = format!(
                                 "**Updated scoreboard `{name}`**
-{} has updated their score to `{score}`{}.",
+        {} has updated their score to `{score}`{}.",
                                 command.user.mention(),
                                 if let Some(prev) = prev {
                                     format!(" (was `{prev}`)")
@@ -430,38 +390,19 @@ impl Subsystem for Scoreboards {
                                     String::new()
                                 }
                             );
-                            create_response(&ctx.http, command, &resp, false).await;
-                            Ok(())
+                            Ok(Some(ActionResponse::new(create_raw_embed(&resp), false)))
                         })
                     })),
                 ))
                 .add_variant(Command::new_stub(
                     "override",
-                    Some(Box::new(move |ctx, command| {
+                    Some(Box::new(move |ctx, command, params| {
                         Box::pin(async {
-                            let name = if let Some(CommandDataOptionValue::String(name)) =
-                                &command.data.options[0].options[0].resolved
-                            {
-                                name
-                            } else {
-                                return Err(crate::Error::InvalidParam(
-                                    "scoreboard name".to_string(),
-                                ));
-                            };
-                            let user = if let Some(CommandDataOptionValue::User(user, _)) =
-                                &command.data.options[0].options[1].resolved
-                            {
-                                user
-                            } else {
-                                return Err(crate::Error::InvalidParam("user".to_string()));
-                            };
-                            let score = if let Some(CommandDataOptionValue::Integer(name)) =
-                                command.data.options[0].options[2].resolved
-                            {
-                                name
-                            } else {
-                                return Err(crate::Error::InvalidParam("score".to_string()));
-                            };
+                            let name = get_param!(params, String, "name");
+                            let user = get_param!(params, User, "user");
+                            let user = command.data.resolved.users.get(&user).unwrap();
+                            let score = *get_param!(params, Integer, "score");
+
                             let mut data = crate::acquire_data_handle!(write ctx);
                             let config = data.get_mut::<Config>().unwrap();
                             let guild = config.guild_mut(&command.guild_id.unwrap());
@@ -472,7 +413,7 @@ impl Subsystem for Scoreboards {
                             crate::drop_data_handle!(data);
                             let resp = format!(
                                 "**Updated scoreboard `{name}`**
-{} has overridden {}'s score to `{score}`{}.",
+        {} has overridden {}'s score to `{score}`{}.",
                                 command.user.mention(),
                                 user.mention(),
                                 if let Some(prev) = prev {
@@ -481,8 +422,7 @@ impl Subsystem for Scoreboards {
                                     String::new()
                                 }
                             );
-                            create_response(&ctx.http, command, &resp, false).await;
-                            Ok(())
+                            Ok(Some(ActionResponse::new(create_raw_embed(&resp), false)))
                         })
                     })),
                 )),

--- a/src/subsystems/text_response.rs
+++ b/src/subsystems/text_response.rs
@@ -1,14 +1,16 @@
+use std::time::Duration;
+
+use serenity::all::{ActionRowComponent, CacheHttp as _, CreateActionRow, CreateModal};
 use serenity::async_trait;
-use serenity::futures::StreamExt;
 use serenity::model::prelude::Message;
 use serenity::model::Permissions;
 use serenity::prelude::Context;
 
 use crate::config::Config;
-use crate::Error;
+use crate::{create_raw_embed, ActionResponse, Error};
 
 use crate::command::{
-    create_embed, create_response, notify_subscribers, Command, Option, OptionType, PermissionType,
+    create_embed, notify_subscribers, Command, Option, OptionType, PermissionType,
 };
 
 use super::Subsystem;
@@ -28,7 +30,7 @@ impl Subsystem for TextResponse {
                 "list",
                 "List all text inputs which have an associated response set.",
                 PermissionType::ServerPerms(Permissions::ADMINISTRATOR),
-                Some(Box::new(move |ctx, command| {
+                Some(Box::new(move |ctx, command, _params| {
                     Box::pin(async move {
                         let data = crate::acquire_data_handle!(read ctx);
                         if let Some(guild) = crate::config::get_guild(&data, &command.guild_id.unwrap()) {
@@ -36,15 +38,14 @@ impl Subsystem for TextResponse {
                                 let mut resp = format!("**{} activation phrase(s):**", response_map.keys().count());
                                 response_map.keys().for_each(|phrase| resp += format!("\n•\t{phrase}").as_str());
                                 crate::drop_data_handle!(data);
-                                create_response(&ctx.http, command, &resp, true).await;
+                                return Ok(Some(ActionResponse::new(create_raw_embed(&resp), true)));
                             } else {
-                                create_response(&ctx.http, command, &"**No activation phrases.**
-Perhaps try adding some?".to_string(), true).await;
+                                return Ok(Some(ActionResponse::new(create_raw_embed("**No activation phrases.**
+Perhaps try adding some?"), true)));
                             }
                         } else {
                             return Err(Error::InvalidChannel);
                         }
-                        Ok(())
                     })
                 })),
             ))
@@ -52,102 +53,73 @@ Perhaps try adding some?".to_string(), true).await;
                 "set",
                 "Set the response the bot gives to a given text input.",
                 PermissionType::ServerPerms(Permissions::ADMINISTRATOR),
-                Some(Box::new(move |ctx, command| {
+                Some(Box::new(move |ctx, command, params| {
                     Box::pin(async move {
-                        let activation_phrase = command.data.options[0]
-                            .options
-                            .iter()
-                            .find(|opt| opt.name == "activation_phrase")
-                            .unwrap()
-                            .value
-                            .as_ref()
-                            .unwrap()
-                            .as_str()
-                            .unwrap();
+                        let activation_phrase = get_param!(params, String, "activation_phrase");
 
-                        let mut new_response = serenity::builder::CreateInputText::default();
-                        new_response
-                            .label(format!("Response for \"{}\"", if activation_phrase.len() > 30 {
+                        let mut new_response = serenity::builder::CreateInputText::new(serenity::all::InputTextStyle::Paragraph, format!("Response for \"{}\"", if activation_phrase.len() > 30 {
                                     activation_phrase.chars().take(27).collect::<String>() + "…"
                                 } else {
                                     activation_phrase.to_string()
-                                }))
-                            .custom_id("new_response_value")
-                            .style(serenity::model::prelude::component::InputTextStyle::Paragraph)
-                            .placeholder("Enter the response to this phrase here, or submit an empty response to unset.")
+                                }), "new_response_value").placeholder("Enter the response to this phrase here, or submit an empty response to unset.")
                             .required(false);
                         let data = crate::acquire_data_handle!(read ctx);
                         if let Some(guild) = crate::config::get_guild(&data, &command.guild_id.unwrap()) {
                             if let Some(response_map) = guild.response_map() {
                                 if let Some(old_response) = response_map.get(activation_phrase) {
-                                    new_response.value(old_response);
+                                    new_response = new_response.value(old_response);
                                 }
                             }
                         }
                         crate::drop_data_handle!(data);
 
-                        let mut components = serenity::builder::CreateComponents::default();
-                        components.create_action_row(|r| r.add_input_text(new_response));
+                        let components = vec![CreateActionRow::InputText(new_response)];
 
                         command
-                            .create_interaction_response(&ctx.http, |r| {
-                                r.kind(serenity::model::application::interaction::InteractionResponseType::Modal);
-                                r.interaction_response_data(|d| {
-                                    d.title("Set text response value")
-                                        .custom_id("set_response_value")
-                                        .set_components(components)
-                                })
-                            })
+                            .create_response(&ctx.http(), serenity::all::CreateInteractionResponse::Modal(CreateModal::new("set_response_value", "Set text response value").components(components)))
                             .await?;
 
                         let guild_id = command.guild_id.unwrap();
 
                         // collect the submitted data
-                        let collector =
-                            serenity::collector::ModalInteractionCollectorBuilder::new(ctx)
+                        if let Some(int) =
+                            serenity::collector::ModalInteractionCollector::new(ctx)
                                 .filter(|int| int.data.custom_id == "set_response_value")
-                                .collect_limit(1)
-                                .build();
+                                .timeout(Duration::new(300, 0)).await {
+                            let mut data = crate::acquire_data_handle!(write ctx);
+                            let config = data.get_mut::<Config>().unwrap();
 
-                        collector
-                .then(|int| async move {
-                    let mut data = crate::acquire_data_handle!(write ctx);
-                    let config = data.get_mut::<Config>().unwrap();
+                            let inputs: Vec<_> = int
+                                .data
+                                .components
+                                .iter()
+                                .flat_map(|r| r.components.iter())
+                                .collect();
 
-                    let inputs: Vec<_> = int
-                        .data
-                        .components
-                        .iter()
-                        .flat_map(|r| r.components.iter())
-                        .collect();
-
-                    for input in inputs.iter() {
-                        if let serenity::model::prelude::component::ActionRowComponent::InputText(it) = input {
-                            if it.custom_id == "new_response_value" {
-                                let guild = config.guild_mut(&guild_id);
-                                let response_map = guild.response_map_mut();
-                                if !it.value.is_empty() {
-                                    response_map.insert(activation_phrase.to_string().to_lowercase(), it.value.clone());
-                                } else {
-                                    response_map.remove(&activation_phrase.to_lowercase());
+                            for input in inputs.iter() {
+                                if let ActionRowComponent::InputText(it) = input {
+                                    if it.custom_id == "new_response_value" {
+                                        let guild = config.guild_mut(&guild_id);
+                                        let response_map = guild.response_map_mut();
+                                        if let Some(it) = &it.value {
+                                            if !it.is_empty() {
+                                            response_map.insert(activation_phrase.to_string().to_lowercase(), it.clone());
+                                        } else {
+                                            response_map.remove(&activation_phrase.to_lowercase());
+                                        }
+                                        config.save();
+                                        }
+                                    }
                                 }
-                                config.save();
                             }
+                            crate::drop_data_handle!(data);
+
+                            // it's now safe to close the modal, so send a response to it
+                            int.create_response(&ctx.http(), serenity::all::CreateInteractionResponse::Acknowledge)
+                            .await?;
                         }
-                    }
-                    crate::drop_data_handle!(data);
 
-                    // it's now safe to close the modal, so send a response to it
-                    int.create_interaction_response(&ctx.http, |r| {
-                        r.kind(serenity::model::prelude::interaction::InteractionResponseType::DeferredUpdateMessage)
-                    })
-                    .await
-                    .ok();
-                })
-                .collect::<Vec<_>>()
-                .await;
-
-                        Ok(())
+                        Ok(None)
                     })
                 })),
             ).add_option(Option::new(
@@ -166,10 +138,13 @@ Perhaps try adding some?".to_string(), true).await;
                 if let Some(response_map) = guild.response_map() {
                     for (activator, response) in response_map {
                         if message.content.to_lowercase().contains(activator) {
-                            if let Ok(channel) = message.channel(&ctx.http).await {
+                            if let Ok(channel) = message.channel(&ctx.http()).await {
                                 if let Some(channel) = channel.guild() {
                                     if let Err(e) = channel
-                                        .send_message(&ctx.http, create_embed(response.to_string()))
+                                        .send_message(
+                                            &ctx.http(),
+                                            create_embed(response.to_string()),
+                                        )
                                         .await
                                     {
                                         notify_subscribers(

--- a/src/subsystems/timeout_monitor.rs
+++ b/src/subsystems/timeout_monitor.rs
@@ -2,23 +2,22 @@ use chrono::{DateTime, Utc};
 use log::{error, info};
 use serde::{Deserialize, Serialize};
 use serenity::{
+    all::{CacheHttp as _, Mentionable as _},
     async_trait, futures,
     model::{
+        application::CommandDataOptionValue,
         id::UserId,
-        prelude::{
-            interaction::application_command::CommandDataOptionValue, Channel, ChannelId,
-            ChannelType, Member,
-        },
+        prelude::{Channel, ChannelId, ChannelType, Member},
         Permissions, Timestamp,
     },
-    prelude::{Context, Mentionable},
+    prelude::Context,
 };
 use tinyvec::array_vec;
 
 use crate::{
-    command::{create_response, Command, OptionType, PermissionType},
+    command::{Command, OptionType, PermissionType},
     config::{get_guild, Config},
-    create_embed, create_raw_embed, create_response_from_embed,
+    create_embed, create_raw_embed, ActionResponse,
 };
 
 use super::Subsystem;
@@ -93,33 +92,26 @@ impl Subsystem for TimeoutMonitor {
         vec![Command::new(
             "timeouts",
             "Timeout statistics for a given user.",
-            PermissionType::ServerPerms(Permissions::USE_SLASH_COMMANDS),
+            PermissionType::ServerPerms(Permissions::USE_APPLICATION_COMMANDS),
             None,
         )
         .add_variant(Command::new(
             "check",
             "Check timeout statistics for a given user.",
-            PermissionType::ServerPerms(Permissions::USE_SLASH_COMMANDS),
-            Some(Box::new(move |ctx, command| {
+            PermissionType::ServerPerms(Permissions::USE_APPLICATION_COMMANDS),
+            Some(Box::new(move |ctx, command, params| {
                 Box::pin(async {
-                    let user = if let Some(CommandDataOptionValue::User(user, _)) =
-                        &command.data.options[0].options[0].resolved
-                    {
-                        user
-                    } else {
-                        return Err(crate::Error::InvalidUser);
-                    };
+                    let user = get_param!(params, User, "user");
                     let data = crate::acquire_data_handle!(read ctx);
                     let mut resp = format!("{} hasn't been timed out!", user.mention());
                     if let Some(guild) = get_guild(&data, &command.guild_id.unwrap()) {
                         if let Some(timeouts) = guild.timeouts() {
-                            if let Some(utd) = timeouts.get(&user.id.to_string()) {
+                            if let Some(utd) = timeouts.get(&user.to_string()) {
                                 resp = format!("{} has been timed out **{}** time(s), for a total of **{} second(s)**.", user.mention(), utd.count, utd.total_time);
                             }
                         }
                     }
-                    create_response(&ctx.http, command, &resp, false).await;
-                    Ok(())
+                    Ok(Some(ActionResponse::new(create_raw_embed(&resp), false)))
                 })
             })),
         )
@@ -133,15 +125,15 @@ impl Subsystem for TimeoutMonitor {
             "configure_announcements",
             "Configure announcements when a user is timed out.",
             PermissionType::ServerPerms(Permissions::MANAGE_CHANNELS),
-            Some(Box::new(move |ctx, command| {
+            Some(Box::new(move |ctx, command, params| {
                 Box::pin(async {
                     // Set announcement channel if it's been supplied.
-                    if let Some(channel_opt) = command.data.options[0].options.iter().find(|opt| opt.name == "channel") {
+                    if let Some(channel_opt) = params.iter().find(|opt| opt.name == "channel") {
                         let mut data = crate::acquire_data_handle!(write ctx);
                         let config = data.get_mut::<Config>().unwrap();
                         let guild = config.guild_mut(&command.guild_id.unwrap());
-                        if let Some(CommandDataOptionValue::Channel(channel)) = &channel_opt.resolved {
-                            let channel = channel.id.to_channel(&ctx.http).await?;
+                        if let CommandDataOptionValue::Channel(channel) = &channel_opt.value {
+                            let channel = channel.to_channel(&ctx.http()).await?;
                             if let Some(announcement_config) = guild.timeouts_announcement_config_mut() {
                                 announcement_config.set_channel(channel);
                             } else {
@@ -156,25 +148,23 @@ impl Subsystem for TimeoutMonitor {
                         let guild = get_guild(&data, &command.guild_id.unwrap());
                         // We don't know this guild.
                         if guild.is_none() {
-                            create_response(&ctx.http, command, &"You must set an announcements channel first!".into(), true).await;
-                            return Ok(());
+                            return Ok(Some(ActionResponse::new(create_raw_embed("You must set an announcements channel first!"), true)));
                         }
                         let announcements_config = guild.unwrap().timeouts_announcement_config();
                         // No announcements channel set!
                         if announcements_config.is_none() {
-                            create_response(&ctx.http, command, &"You must set an announcements channel first!".into(), true).await;
-                            return Ok(());
+                            return Ok(Some(ActionResponse::new(create_raw_embed("You must set an announcements channel first!"), true)));
                         }
                         // There is an announcements channel set, so we can continue with that.
                     };
 
                     // Set announcement prefix if it's been supplied.
-                    if let Some(prefix_opt) = command.data.options[0].options.iter().find(|opt| opt.name == "announcement_prefix") {
+                    if let Some(prefix_opt) = params.iter().find(|opt| opt.name == "announcement_prefix") {
                         let mut data = crate::acquire_data_handle!(write ctx);
                         let config = data.get_mut::<Config>().unwrap();
                         let guild = config.guild_mut(&command.guild_id.unwrap());
                         let announcement_config = guild.timeouts_announcement_config_mut().unwrap();
-                        if let Some(CommandDataOptionValue::String(prefix)) = &prefix_opt.resolved {
+                        if let CommandDataOptionValue::String(prefix) = &prefix_opt.value {
                             announcement_config.set_prefix(prefix);
                             config.save();
                         }
@@ -186,10 +176,9 @@ impl Subsystem for TimeoutMonitor {
                     let resp = format!("**Timeouts announcement config updated!**
 Channel: {}
 Announcement text: {}",
-                        announcements_config.channel().to_channel(&ctx.http).await?,
+                        announcements_config.channel().to_channel(&ctx.http()).await?,
                         announcements_config.announcement_text());
-                    create_response(&ctx.http, command, &resp, true).await;
-                    Ok(())
+                    Ok(Some(ActionResponse::new(create_raw_embed(&resp), true)))
                 })
             })),
         )
@@ -209,7 +198,7 @@ Announcement text: {}",
             "stop_announcements",
             "Stop all announcements. Unsets all configuration values.",
             PermissionType::ServerPerms(Permissions::MANAGE_CHANNELS),
-            Some(Box::new(move |ctx, command| {
+            Some(Box::new(move |ctx, command, _params| {
                 Box::pin(async {
                     let mut data = crate::acquire_data_handle!(write ctx);
                     let config = data.get_mut::<Config>().unwrap();
@@ -217,38 +206,29 @@ Announcement text: {}",
                     let announcements_config = guild.timeouts_announcement_config_mut();
                     // No announcements channel set!
                     if announcements_config.is_none() {
-                        create_response(&ctx.http, command, &"Announcements haven't been set up yet.".into(), true).await;
-                        return Ok(());
+                        return Ok(Some(ActionResponse::new(create_raw_embed("Announcements haven't been set up yet."), true)));
                     }
                     // There is an announcements channel set.
                     guild.timeouts_announcement_uninit();
                     config.save();
                     crate::drop_data_handle!(data);
 
-                    create_response(&ctx.http, command, &"Announcements have been uninitialised.".into(), true).await;
-                    Ok(())
+                    Ok(Some(ActionResponse::new(create_raw_embed("Announcements have been uninitialised."), true)))
                 })
             })),
         ))
         .add_variant(Command::new(
             "leaderboard",
             "Display the leaderboard for timeout statistics.",
-            PermissionType::ServerPerms(Permissions::USE_SLASH_COMMANDS),
-            Some(Box::new(move |ctx, command| {
+            PermissionType::ServerPerms(Permissions::USE_APPLICATION_COMMANDS),
+            Some(Box::new(move |ctx, command, params| {
                 Box::pin(async {
-                    let sort_by = if let Some(CommandDataOptionValue::String(option)) =
-                        &command.data.options[0].options[0].resolved
-                    {
-                        option.to_lowercase()
-                    } else {
-                        return Err(crate::Error::InvalidParam("Option `sort_by` missing on Timeout Ranking invocation.".to_string()));
-                    };
-                    let mut resp = create_raw_embed(format!("**Top 10 Timeout leaderboard** (sorted by {sort_by})"));
+                    let metric = get_param!(params, String, "metric").to_lowercase();
                     let mut users = String::new();
                     let mut counts = String::new();
                     let mut times = String::new();
-                    let sort_by= |(_, utd_a): &(String, UserTimeoutData), (_uid_b, utd_b): &(String, UserTimeoutData)| {
-                        match sort_by.as_str() {
+                    let sort_by = |(_, utd_a): &(String, UserTimeoutData), (_uid_b, utd_b): &(String, UserTimeoutData)| {
+                        match metric.as_str() {
                             "quantity" => utd_b.count.cmp(&utd_a.count),
                             "total time" => utd_b.total_time.cmp(&utd_a.total_time),
                             _ => unreachable!() }
@@ -260,7 +240,7 @@ Announcement text: {}",
                             entries.sort_unstable_by(sort_by);
                             let iter = entries.iter().take(10);
                             users = futures::future::try_join_all(iter.clone().map(|(uid, _)| async {
-                                Ok::<String, crate::Error>(UserId::from(uid.parse::<u64>().unwrap()).to_user(&ctx.http).await?.mention().to_string())
+                                Ok::<String, crate::Error>(UserId::from(uid.parse::<u64>().unwrap()).to_user(&ctx.http()).await?.mention().to_string())
                             })).await?.join("\n");
                             counts = iter.clone().map(|(_, utd)| { utd.count.to_string() }).collect::<Vec<String>>().join("\n");
                             times = iter.map(|(_, utd)| {
@@ -271,9 +251,8 @@ Announcement text: {}",
                             }).collect::<Vec<String>>().join("\n");
                         }
                     }
-                    resp.field("User", users, true).field("Count", counts, true).field("Total time", times, true);
-                    create_response_from_embed(&ctx.http, command, resp, false).await;
-                    Ok(())
+                    let resp = create_raw_embed(format!("**Top 10 Timeout leaderboard** (sorted by {metric})")).field("User", users, true).field("Count", counts, true).field("Total time", times, true);
+                    Ok(Some(ActionResponse::new(resp, false)))
                 })
             })),
         )
@@ -344,14 +323,14 @@ Announcement text: {}",
                     if let Some(announcements_config) = guild.timeouts_announcement_config() {
                         if let Some(channel) = announcements_config
                             .channel
-                            .to_channel(&ctx.http)
+                            .to_channel(&ctx.http())
                             .await
                             .unwrap()
                             .guild()
                         {
                             channel
                                 .send_message(
-                                    &ctx.http,
+                                    &ctx.http(),
                                     create_embed(format!(
                                         "{}{}{} has been timed out {} times now!",
                                         announcements_config.prefix(),


### PR DESCRIPTION
This includes a workaround for a bug introduced in this version, where IntegerInput bounds are specified as u64 when they should be i64, and includes some relatively-light refactors of the Loki-Serenity boundary to make some things a little cleaner.

Closes #20 