### PR TITLE
Nickname metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "loki-discord-bot"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "const_format",
@@ -914,9 +914,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
@@ -949,9 +949,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki-discord-bot"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 description = "A bot to serve various meme-related purposes within a personal Discord server."
 readme = "README.md"
@@ -50,7 +50,7 @@ chrono = { version = "^0.4", features = ["serde"] }
 rand = "^0.8.5"
 tinyvec = "^1.6.0"
 # Added due to reqwest dependency problems when cross-compiling for RPi
-openssl = { version = "^0.10.32", features = ["vendored"] }
+openssl = { version = "^0.10.66", features = ["vendored"] }
 const_format = { version = "0.2.32", optional = true }
 
 [dependencies.serenity]

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -90,19 +90,21 @@ impl<'a> Command<'a> {
     /// ## Example
     ///
     /// ```
-    /// Command::new(
+    /// use loki_discord_bot::{PermissionType, Command};
+    ///
+    /// let _command = Command::new(
     ///     "name",
     ///     "A description of what the command does.",
     ///     PermissionType::Universal,
     ///     Some(
-    ///         Box::new(move |ctx, command| {
+    ///         Box::new(move |ctx, command, params| {
     ///             Box::pin(async {
     ///                 // do something here
-    ///                 Ok(())
+    ///                 Ok(None) // no response needed
     ///             })
     ///         })
     ///     ),
-    /// ),
+    /// );
     /// ```
     pub fn new(
         name: &'a str,

--- a/src/subsystems/nickname_lottery.rs
+++ b/src/subsystems/nickname_lottery.rs
@@ -1,7 +1,11 @@
-use std::{collections::HashMap, str::FromStr, time::Duration};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    str::FromStr,
+    time::Duration,
+};
 
-use chrono::{Datelike, TimeZone};
-use log::{error, info, warn};
+use chrono::{DateTime, Datelike, TimeZone, Utc};
+use log::{error, info, trace, warn};
 use rand::{
     distributions::Distribution,
     seq::{IteratorRandom, SliceRandom},
@@ -29,67 +33,81 @@ use crate::{
 use super::Subsystem;
 
 /// (30 mins, 5 days) in seconds.
-const REFRESH_INTERVAL: (u64, u64) = (1_800, 432_000);
+const DEFAULT_REFRESH_INTERVAL: (u64, u64) = (1_800, 432_000);
 
 #[derive(Default)]
 pub struct NicknameLottery;
 
+/// A [Guild]'s collective nickname lottery data, including configuration.
 #[derive(Serialize, Deserialize, Default)]
 pub struct NicknameLotteryGuildData {
     /// HashMap of stringified [UserId]s to their respective list of specific nicknames, or [None] if they are excluded from the system.
-    user_specific_nicknames: HashMap<String, Vec<String>>,
-    /// Channel that the bot demands a name change in, if it fails to do so itself. The bot will 'silently' fail if this is not set.
-    complaint_channel: Option<ChannelId>,
+    user_specific_nicknames: HashMap<String, Vec<NicknameData>>,
+    /// Channel that the bot demands a name change in, if it fails to do so itself, and announces any nickname changes during April Fool's.
+    /// The bot will 'silently' fail, and make no announcements, if this is not set.
+    channel: Option<ChannelId>,
     /// An override for the title of the bot name change demand. Uses default if [None].
     title_override: Option<String>,
+    /// An override for the refresh interval for this guild. Uses [DEFAULT_REFRESH_INTERVAL] if [None].
+    refresh_interval: Option<(u64, u64)>,
 }
 
 impl NicknameLotteryGuildData {
-    /// Deconstructs a list of nicknames, separated by newlines, to into a [Vec].
-    pub fn deconstruct_nickname_string(nicks: &str) -> Vec<String> {
-        nicks
-            .split('\n')
-            .filter_map(|n| {
-                let n = n.trim();
-                if n.is_empty() {
-                    return None;
-                }
-                Some(n.to_string().chars().take(30).collect())
-            })
-            .collect()
+    /// Returns the list of specific nicknames for a given [UserId], or [None] if the user does not have any.
+    pub fn user_nicknames(&self, user: &UserId) -> Option<&Vec<NicknameData>> {
+        self.user_specific_nicknames.get(&user.to_string())
     }
 
-    /// Constructs a [String] listing the nicknames separated by newlines.
-    pub fn construct_nickname_string(nicks: &[String]) -> String {
-        nicks.join("\n")
-    }
-
-    /// Returns the list of specific nicknames for a given [UserId] as a [String], with each entry on a separate line.
-    pub fn user_nicknames_string(&self, user: &UserId) -> String {
+    /// Add a [NicknameData] to a [UserId], returning the index of the added nickname.
+    pub fn add_user_nickname(&mut self, user: &UserId, nickname: NicknameData) -> usize {
+        trace!("Adding nickname for {user:?}: {nickname:?}");
+        self.user_specific_nicknames
+            .entry(user.to_string())
+            .or_default()
+            .push(nickname);
         self.user_specific_nicknames
             .get(&user.to_string())
-            .map_or(String::default(), |n| Self::construct_nickname_string(n))
+            .unwrap()
+            .len()
+            - 1
     }
 
-    /// Sets the list of specific nicknames based for a given [UserId].
-    pub fn set_user_nicknames(&mut self, user: &UserId, nicks: &[&str]) {
-        if nicks.is_empty() {
-            self.user_specific_nicknames.remove(&user.to_string());
-        } else {
-            self.user_specific_nicknames.insert(
-                user.to_string(),
-                nicks.iter().map(|s| s.to_string()).collect(),
-            );
+    pub fn set_user_nickname_context(&mut self, user: &UserId, n: usize, context: String) {
+        trace!("Adding context for {user:?} nickname #{n}: {context}");
+        assert!(n > 0);
+        self.user_specific_nicknames
+            .entry(user.to_string())
+            .and_modify(|nicknames| {
+                assert!(n <= nicknames.len());
+                nicknames.get_mut(n - 1).unwrap().set_context(context);
+            });
+    }
+
+    /// Remove the `n`th [NicknameData] from a [UserId].
+    pub fn remove_user_nickname(&mut self, user: &UserId, n: usize) {
+        trace!("Removing nickname #{n} for {user:?}");
+        assert!(n > 0);
+        let entry = self
+            .user_specific_nicknames
+            .entry(user.to_string())
+            .and_modify(|nicknames| {
+                assert!(n <= nicknames.len());
+                nicknames.remove(n - 1);
+            });
+        if let Entry::Occupied(entry) = entry {
+            if entry.get().is_empty() {
+                entry.remove();
+            }
         }
     }
 
     /// Select a nickname for the given [UserId], or [None] if the user is excluded.
-    pub fn get_nickname_for_user(&self, user: &UserId) -> Option<String> {
+    pub fn get_nickname_for_user(&self, user: &UserId) -> Option<&String> {
         self.user_specific_nicknames
             .get(&user.to_string())
             .map(|n| n.choose(&mut rand::thread_rng()))
             .unwrap_or_default()
-            .map(|s| s.to_string())
+            .map(|s| s.nickname())
     }
 
     /// Select a [UserId] to change the nickname of.
@@ -100,14 +118,14 @@ impl NicknameLotteryGuildData {
             .map(|id| UserId::new(u64::from_str(id).unwrap()))
     }
 
-    /// Set the complaints channel.
-    pub fn set_complaints_channel(&mut self, channel: Option<ChannelId>) {
-        self.complaint_channel = channel;
+    /// Set the channel.
+    pub fn set_channel(&mut self, channel: Option<ChannelId>) {
+        self.channel = channel;
     }
 
-    /// Get the complaints channel, if set.
-    pub fn complaints_channel(&self) -> Option<ChannelId> {
-        self.complaint_channel
+    /// Get the channel, if set.
+    pub fn channel(&self) -> Option<ChannelId> {
+        self.channel
     }
 
     /// Set title override.
@@ -123,6 +141,68 @@ impl NicknameLotteryGuildData {
             "Bot demands new nickname".to_string()
         }
     }
+
+    /// Get the refresh interval for this guild.
+    pub fn refresh_interval(&self) -> Option<&(u64, u64)> {
+        self.refresh_interval.as_ref()
+    }
+
+    /// Set a custom refresh interval for this guild, or reset back to the default if [None].
+    pub fn set_refresh_interval(&mut self, refresh_interval: Option<(u64, u64)>) {
+        self.refresh_interval = refresh_interval;
+    }
+}
+
+/// Data for a single nickname, including metadata.
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+pub struct NicknameData {
+    /// The nickname itself.
+    nickname: String,
+    /// The user who added this nickname.
+    author: Option<UserId>,
+    /// The time that this nickname was created.
+    time: Option<DateTime<Utc>>,
+    /// Context for the nickname, if any.
+    context: Option<String>,
+}
+
+impl NicknameData {
+    /// Create a new nickname with the supplied data. `time` will be set to the current time.
+    pub fn new(nickname: String, author: UserId) -> Self {
+        Self {
+            nickname,
+            author: Some(author),
+            time: Some(Utc::now()),
+            context: None,
+        }
+    }
+
+    /// Get the actual nickname this [NicknameData] represents.
+    pub fn nickname(&self) -> &String {
+        &self.nickname
+    }
+
+    /// Get the [UserId] that created this nickname.
+    /// [None] if this is unknown, such as if the data was migrated from a pre-v0.11 list of nicknames.
+    pub fn author(&self) -> Option<&UserId> {
+        self.author.as_ref()
+    }
+
+    /// Get the time that this nickname was created.
+    /// [None] if this is unknown, such as if the data was migrated from a pre-v0.11 list of nicknames.
+    pub fn time(&self) -> Option<&DateTime<Utc>> {
+        self.time.as_ref()
+    }
+
+    /// Get the context behind this nickname, if any was provided.
+    /// This is optional, so may return [None].
+    pub fn context(&self) -> Option<&String> {
+        self.context.as_ref()
+    }
+
+    pub fn set_context(&mut self, context: String) {
+        self.context = Some(context);
+    }
 }
 
 #[async_trait]
@@ -131,214 +211,694 @@ impl Subsystem for NicknameLottery {
         vec![Command::new(
             "nickname_lottery",
             "Controls for the nickname lottery.",
-            PermissionType::ServerPerms(Permissions::MANAGE_NICKNAMES),
+            PermissionType::ServerPerms(Permissions::USE_APPLICATION_COMMANDS),
             None,
         )
         .add_variant(
             Command::new(
-                "set_nicknames",
-                "Set the list of nicknames that can be applied to a specific user.",
-                PermissionType::ServerPerms(Permissions::MANAGE_NICKNAMES),
-                Some(Box::new(move |ctx, command, params| {
-                    Box::pin(async move {
-                        let user = get_param!(params, User, "user");
-                        let user = command.data.resolved.users.get(user).unwrap();
-                        let guild_id = command.guild_id.unwrap();
+                "user_nicknames",
+                "Manage individual users' nicknames.",
+                PermissionType::ServerPerms(Permissions::USE_APPLICATION_COMMANDS),
+                None,
+            )
+            .add_variant(
+                Command::new(
+                    "add",
+                    "Add a new nickname for a user.",
+                    PermissionType::ServerPerms(Permissions::MANAGE_NICKNAMES),
+                    Some(Box::new(move |ctx, command, params| {
+                        Box::pin(async move {
+                            let user = get_param!(params, User, "user");
+                            let user = command.data.resolved.users.get(user).unwrap();
+                            let nickname = get_param!(params, String, "nickname").clone();
+                            let guild_id = command.guild_id.unwrap();
 
-                        let data = crate::acquire_data_handle!(read ctx);
-                        let guild = get_guild(&data, &guild_id).unwrap();
-                        let nickname_lottery_data = guild.nickname_lottery_data();
+                            info!(
+                                "[Guild: {}] Adding nickname {nickname} for {} ({}) (author: {} ({}))",
+                                guild_id, user.name, user.id, command.user.name, command.user.id
+                            );
 
-                        info!(
-                            "[Guild: {}] Updating nickname list for {} ({})",
-                            guild_id, user.name, user.id
-                        );
+                            let data = crate::acquire_data_handle!(read ctx);
+                            let guild = get_guild(&data, &guild_id).unwrap();
+                            let nickname_lottery_data = guild.nickname_lottery_data();
 
-                        let old_nicknames = nickname_lottery_data.user_nicknames_string(&user.id);
+                            if nickname_lottery_data.user_nicknames(&user.id).map(|nicknames| nicknames.iter().any(|nd| *nd.nickname() == nickname)).unwrap_or(false) {
+                                info!(
+                                    "[Guild: {}] Nickname {nickname} for {} ({}) already exists; ignoring.",
+                                    guild_id, user.name, user.id
+                                );
+                                return Ok(Some(ActionResponse::new(
+                                        create_raw_embed(format!("Nickname {nickname} already exists for {}.", user.mention())),
+                                        true,
+                                    )));
+                            }
+                            crate::drop_data_handle!(data);
 
-                        let input_nicks = serenity::builder::CreateInputText::new(
-                            serenity::all::InputTextStyle::Paragraph,
-                            "Nicknames list",
-                            "nicknames_list",
-                        )
-                        .placeholder("List of nicknames, each on a new line (or blank to unset).")
-                        .required(false)
-                        .value(old_nicknames);
-                        crate::drop_data_handle!(data);
+                            let nd = NicknameData::new(nickname.clone(), command.user.id);
 
-                        let components =
-                            vec![serenity::all::CreateActionRow::InputText(input_nicks)];
-
-                        command
-                            .create_response(
-                                &ctx.http(),
-                                serenity::all::CreateInteractionResponse::Modal(
-                                    CreateModal::new(
-                                        user.id.to_string() + "_set_nicknames",
-                                        format!("{}'s nicknames", user.name),
-                                    )
-                                    .components(components),
-                                ),
-                            )
-                            .await?;
-
-                        let userid = user.id;
-                        // collect the submitted data
-                        if let Some(int) = serenity::collector::ModalInteractionCollector::new(ctx)
-                            .filter(move |int| {
-                                int.data.custom_id == userid.to_string() + "_set_nicknames"
-                            })
-                            .timeout(Duration::new(300, 0))
-                            .await
-                        {
                             let mut data = crate::acquire_data_handle!(write ctx);
                             let config = data.get_mut::<Config>().unwrap();
                             let guild = config.guild_mut(&guild_id.clone());
                             let nickname_lottery_data = guild.nickname_lottery_data_mut();
 
-                            let inputs: Vec<_> = int
-                                .data
-                                .components
-                                .iter()
-                                .flat_map(|r| r.components.iter())
-                                .collect();
+                            let n = nickname_lottery_data.add_user_nickname(&user.id, nd);
 
-                            for input in inputs.iter() {
-                                if let serenity::all::ActionRowComponent::InputText(it) = input {
-                                    if it.custom_id == "nicknames_list" {
-                                        if let Some(it) = &it.value {
-                                            nickname_lottery_data.set_user_nicknames(
-                                            &user.id,
-                                            &NicknameLotteryGuildData::deconstruct_nickname_string(
-                                                &it.clone(),
-                                            )
-                                            .iter()
-                                            .map(|n| n.as_str())
-                                            .collect::<Vec<&str>>(),
-                                        );
+                            config.save();
+                            crate::drop_data_handle!(data);
+
+                            let input_context = serenity::builder::CreateInputText::new(
+                                serenity::all::InputTextStyle::Paragraph,
+                                "Nickname context",
+                                "nickname_context",
+                            )
+                            .placeholder("Any context about this nickname to offset future forgetfulness.")
+                            .required(false);
+
+                            let components =
+                                vec![serenity::all::CreateActionRow::InputText(input_context)];
+
+                            command
+                                .create_response(
+                                    &ctx.http(),
+                                    serenity::all::CreateInteractionResponse::Modal(
+                                        CreateModal::new(
+                                            user.id.to_string() + "_" + &nickname + "_context",
+                                            format!("Context for {nickname}"),
+                                        )
+                                        .components(components),
+                                    ),
+                                )
+                                .await?;
+
+                            let userid = user.id;
+                            let nick = nickname.clone();
+                            // collect the submitted data
+                            if let Some(int) = serenity::collector::ModalInteractionCollector::new(ctx)
+                                .filter(move |int| {
+                                    int.data.custom_id == userid.to_string() + "_" + &nick + "_context"
+                                })
+                                .timeout(Duration::new(300, 0))
+                                .await
+                            {
+                                let mut data = crate::acquire_data_handle!(write ctx);
+                                let config = data.get_mut::<Config>().unwrap();
+                                let guild = config.guild_mut(&guild_id.clone());
+                                let nickname_lottery_data = guild.nickname_lottery_data_mut();
+
+                                let inputs: Vec<_> = int
+                                    .data
+                                    .components
+                                    .iter()
+                                    .flat_map(|r| r.components.iter())
+                                    .collect();
+
+                                for input in inputs.iter() {
+                                    if let serenity::all::ActionRowComponent::InputText(it) = input {
+                                        if it.custom_id == "nickname_context" {
+                                            if let Some(it) = &it.value {
+                                                if !it.is_empty() {
+                                                    nickname_lottery_data.set_user_nickname_context(&user.id, n + 1, it.to_string());
+                                                }
+                                            }
                                         }
                                     }
                                 }
+
+                                config.save();
+
+                                crate::drop_data_handle!(data);
+
+                                // it's now safe to close the modal, so send a response to it
+                                int.create_response(
+                                    &ctx.http(),
+                                    serenity::all::CreateInteractionResponse::Acknowledge,
+                                )
+                                .await?;
                             }
+
+                            Ok(None)
+                        })
+                    })),
+                )
+                .add_option(crate::Option::new(
+                    "user",
+                    "The user to add the nickname for.",
+                    OptionType::User,
+                    true,
+                ))
+                .add_option(crate::Option::new(
+                    "nickname",
+                    "The nickname to add for the user.",
+                    OptionType::StringInput(Some(1), Some(30)),
+                    true,
+                )),
+            )
+            .add_variant(
+                Command::new(
+                    "remove",
+                    "Remove a nickname from a user.",
+                    PermissionType::ServerPerms(Permissions::MANAGE_NICKNAMES),
+                    Some(Box::new(move |ctx, command, params| {
+                        Box::pin(async move {
+                            let user = get_param!(params, User, "user");
+                            let user = command.data.resolved.users.get(user).unwrap();
+                            let n = *get_param!(params, Integer, "number");
+                            let guild_id = command.guild_id.unwrap();
+
+                            if n < 1 {
+                                return Ok(Some(ActionResponse::new(
+                                        create_raw_embed("**`number` must be greater than 0**
+Check the user's nickname list for valid numbers to remove!"),
+                                        true,
+                                    )))
+                            }
+
+                            info!(
+                                "[Guild: {}] Removing nickname #{n} for {} ({})",
+                                guild_id, user.name, user.id,
+                            );
+
+                            let data = crate::acquire_data_handle!(read ctx);
+                            let guild = get_guild(&data, &guild_id).unwrap();
+                            let nickname_lottery_data = guild.nickname_lottery_data();
+
+                            if nickname_lottery_data.user_nicknames(&user.id).map(|nicknames| n as usize > nicknames.len()).unwrap_or(true) {
+                                info!(
+                                    "[Guild: {}] Nickname #{n} does not exist for {} ({}); ignoring.",
+                                    guild_id, user.name, user.id
+                                );
+                                return Ok(Some(ActionResponse::new(
+                                    create_raw_embed(format!("**Nickname #{n} does not exist for {}**
+Consider checking their nickname list for valid number to remove.",
+                                        user.mention())),
+                                    true,
+                                )));
+                            }
+                            let nickname = &nickname_lottery_data.user_nicknames(&user.id).unwrap()[n as usize - 1].clone();
+                            crate::drop_data_handle!(data);
+
+                            let mut data = crate::acquire_data_handle!(write ctx);
+                            let config = data.get_mut::<Config>().unwrap();
+                            let guild = config.guild_mut(&guild_id.clone());
+                            let nickname_lottery_data = guild.nickname_lottery_data_mut();
+
+                            nickname_lottery_data.remove_user_nickname(&user.id, n as usize);
 
                             config.save();
 
-                            // it's now safe to close the modal, so send a response to it
-                            int.create_response(
-                                &ctx.http(),
-                                serenity::all::CreateInteractionResponse::Acknowledge,
-                            )
-                            .await?;
-                        }
+                            crate::drop_data_handle!(data);
 
-                        Ok(None)
-                    })
-                })),
+                            Ok(Some(ActionResponse::new(
+                                create_raw_embed(
+                                    format!("**Removed nickname '{}' for {}**
+Originally added by {} (<t:{}:F>)
+**Context:**
+{}",
+                                    nickname.nickname(), user.mention(),
+                                    nickname.author()
+                                            .map(|uid| uid.mention().to_string())
+                                            .unwrap_or("`user not known`".to_string()),
+                                    nickname.time()
+                                            .map(|time| time.timestamp().to_string())
+                                            .unwrap_or("`time not known`".to_string()),
+                                    nickname.context()
+                                            .unwrap_or(&"No context provided.".to_string()),
+                                    )
+                                ),
+                                true,
+                            )))
+                        })
+                    })),
+                )
+                .add_option(crate::Option::new(
+                    "user",
+                    "The user to add the nickname for.",
+                    OptionType::User,
+                    true,
+                ))
+                .add_option(crate::Option::new(
+                    "number",
+                    "The number of the nickname to remove, as reported in the user's nickname list.",
+                    OptionType::IntegerInput(Some(1), None),
+                    true,
+                )),
             )
-            .add_option(crate::Option::new(
-                "user",
-                "The user to set the nickname list for.",
-                OptionType::User,
-                true,
-            )),
+            .add_variant(
+                Command::new(
+                    "set_context",
+                    "Set context for a user's nickname.",
+                    PermissionType::ServerPerms(Permissions::MANAGE_NICKNAMES),
+                    Some(Box::new(move |ctx, command, params| {
+                        Box::pin(async move {
+                            let user = get_param!(params, User, "user");
+                            let user = command.data.resolved.users.get(user).unwrap();
+                            let n = *get_param!(params, Integer, "number");
+                            let guild_id = command.guild_id.unwrap();
+
+                            if n < 1 {
+                                return Ok(Some(ActionResponse::new(
+                                        create_raw_embed("**`number` must be greater than 0**
+Check the user's nickname list for valid numbers to remove!"),
+                                        true,
+                                    )))
+                            }
+
+                            info!(
+                                "[Guild: {}] Updating context for nickname #{n} for {} ({})",
+                                guild_id, user.name, user.id,
+                            );
+
+                            let data = crate::acquire_data_handle!(read ctx);
+                            let guild = get_guild(&data, &guild_id).unwrap();
+                            let nickname_lottery_data = guild.nickname_lottery_data();
+
+                            if nickname_lottery_data.user_nicknames(&user.id).map(|nicknames| n as usize > nicknames.len()).unwrap_or(true) {
+                                info!(
+                                    "[Guild: {}] Nickname #{n} does not exist for {} ({}); ignoring.",
+                                    guild_id, user.name, user.id
+                                );
+                                return Ok(Some(ActionResponse::new(
+                                    create_raw_embed(format!("**Nickname #{n} does not exist for {}**
+Consider checking their nickname list for valid number to remove.",
+                                        user.mention())),
+                                    true,
+                                )));
+                            }
+                            let nickname = &nickname_lottery_data.user_nicknames(&user.id).unwrap()[n as usize - 1].clone();
+                            crate::drop_data_handle!(data);
+
+                            let input_context = serenity::builder::CreateInputText::new(
+                                serenity::all::InputTextStyle::Paragraph,
+                                "Nickname context",
+                                "nickname_context",
+                            )
+                            .placeholder("Any context about this nickname to offset future forgetfulness.")
+                            .value(nickname.context().cloned().unwrap_or_else(|| String::from("")))
+                            .required(true);
+
+                            let components =
+                                vec![serenity::all::CreateActionRow::InputText(input_context)];
+
+                            command
+                                .create_response(
+                                    &ctx.http(),
+                                    serenity::all::CreateInteractionResponse::Modal(
+                                        CreateModal::new(
+                                            user.id.to_string() + "_" + nickname.nickname() + "_context",
+                                            format!("Context for {}", nickname.nickname()),
+                                        )
+                                        .components(components),
+                                    ),
+                                )
+                                .await?;
+
+                            let userid = user.id;
+                            let nick = nickname.nickname().clone();
+                            // collect the submitted data
+                            if let Some(int) = serenity::collector::ModalInteractionCollector::new(ctx)
+                                .filter(move |int| {
+                                    int.data.custom_id == userid.to_string() + "_" + &nick + "_context"
+                                })
+                                .timeout(Duration::new(300, 0))
+                                .await
+                            {
+                                let mut data = crate::acquire_data_handle!(write ctx);
+                                let config = data.get_mut::<Config>().unwrap();
+                                let guild = config.guild_mut(&guild_id.clone());
+                                let nickname_lottery_data = guild.nickname_lottery_data_mut();
+
+                                let inputs: Vec<_> = int
+                                    .data
+                                    .components
+                                    .iter()
+                                    .flat_map(|r| r.components.iter())
+                                    .collect();
+
+                                for input in inputs.iter() {
+                                    if let serenity::all::ActionRowComponent::InputText(it) = input {
+                                        if it.custom_id == "nickname_context" {
+                                            if let Some(it) = &it.value {
+                                                if !it.is_empty() {
+                                                    nickname_lottery_data.set_user_nickname_context(&user.id, n as usize, it.to_string());
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+
+                                config.save();
+
+                                crate::drop_data_handle!(data);
+
+                                // it's now safe to close the modal, so send a response to it
+                                int.create_response(
+                                    &ctx.http(),
+                                    serenity::all::CreateInteractionResponse::Acknowledge,
+                                )
+                                .await?;
+                            }
+                            Ok(None)
+                        })
+                    })),
+                )
+                .add_option(crate::Option::new(
+                    "user",
+                    "The user to add the nickname for.",
+                    OptionType::User,
+                    true,
+                ))
+                .add_option(crate::Option::new(
+                    "number",
+                    "The number of the nickname to remove, as reported in the user's nickname list.",
+                    OptionType::IntegerInput(Some(1), None),
+                    true,
+                )),
+            )
+            .add_variant(
+                Command::new(
+                    "info",
+                    "Get more information about a nickname for a user.",
+                    PermissionType::ServerPerms(Permissions::USE_APPLICATION_COMMANDS),
+                    Some(Box::new(move |ctx, command, params| {
+                        Box::pin(async move {
+                            let user = get_param!(params, User, "user");
+                            let user = command.data.resolved.users.get(user).unwrap();
+                            let n = *get_param!(params, Integer, "number");
+                            let guild_id = command.guild_id.unwrap();
+
+                            if n < 1 {
+                                return Ok(Some(ActionResponse::new(
+                                        create_raw_embed("**`number` must be greater than 0**
+Check the user's nickname list for valid numbers!"),
+                                        true,
+                                    )))
+                            }
+
+                            let data = crate::acquire_data_handle!(read ctx);
+                            let guild = get_guild(&data, &guild_id).unwrap();
+                            let nickname_lottery_data = guild.nickname_lottery_data();
+
+                            if nickname_lottery_data.user_nicknames(&user.id).map(|nicknames| n as usize > nicknames.len()).unwrap_or(true) {
+                                info!(
+                                    "[Guild: {}] Nickname #{n} does not exist for {} ({}); ignoring.",
+                                    guild_id, user.name, user.id
+                                );
+                                return Ok(Some(ActionResponse::new(
+                                    create_raw_embed(format!("**Nickname #{n} does not exist for {}**
+Consider checking their nickname list for valid number to remove.",
+                                        user.mention())),
+                                    true,
+                                )));
+                            }
+                            let nickname = &nickname_lottery_data.user_nicknames(&user.id).unwrap()[n as usize - 1].clone();
+                            crate::drop_data_handle!(data);
+
+                            Ok(Some(ActionResponse::new(
+                                create_raw_embed(
+                                    format!("**Nickname '{}' for {}**
+Originally added by {} (<t:{}:F>)
+**Context:**
+{}",
+                                    nickname.nickname(), user.mention(),
+                                    nickname.author()
+                                            .map(|uid| uid.mention().to_string())
+                                            .unwrap_or("`user not known`".to_string()),
+                                    nickname.time()
+                                            .map(|time| time.timestamp().to_string())
+                                            .unwrap_or("`time not known`".to_string()),
+                                    nickname.context()
+                                            .unwrap_or(&"No context provided.".to_string()),
+                                    )
+                                ),
+                                true,
+                            )))
+                        })
+                    })),
+                )
+                .add_option(crate::Option::new(
+                    "user",
+                    "The user whose nickname you seek more information about.",
+                    OptionType::User,
+                    true,
+                ))
+                .add_option(crate::Option::new(
+                    "number",
+                    "The number of the nickname to get information about, as reported in the user's nickname list.",
+                    OptionType::IntegerInput(Some(1), None),
+                    true,
+                )),
+            )
+            .add_variant(
+                Command::new(
+                    "list",
+                    "List all nicknames set for the user.",
+                    PermissionType::ServerPerms(Permissions::USE_APPLICATION_COMMANDS),
+                    Some(Box::new(move |ctx, command, params| {
+                        Box::pin(async {
+                            let user = get_param!(params, User, "user");
+                            let user = command.data.resolved.users.get(user).unwrap();
+                            let data = crate::acquire_data_handle!(read ctx);
+                            if let Some(guild) = get_guild(&data, &command.guild_id.unwrap()) {
+                                let lottery_data = guild.nickname_lottery_data();
+                                if let Some(nicknames) = lottery_data.user_nicknames(&user.id) {
+                                    let mut list = format!("**Nicknames for {}**", user.mention());
+                                    for (i, nickname) in nicknames.iter().enumerate() {
+                                        list += &format!("\n{}. {}", i + 1, nickname.nickname());
+                                    }
+                                    Ok(Some(ActionResponse::new(
+                                        create_raw_embed(list),
+                                        true,
+                                    )))
+                                } else {
+                                    Ok(Some(ActionResponse::new(
+                                        create_raw_embed(format!("{} has no nicknames in this server.", user.mention())),
+                                        true,
+                                    )))
+                                }
+                            } else {
+                                error!("Guild command called in an unitialised guild {}", command.guild_id.unwrap());
+                                Ok(None)
+                            }
+                        })
+                    })),
+                )
+                .add_option(crate::Option::new(
+                    "user",
+                    "The user to get the nickname list for.",
+                    OptionType::User,
+                    true,
+                ))
+            )
         )
         .add_variant(
             Command::new(
-                "configure_announcements",
-                "Configure announcements when the bot fails to change a user's nickname.",
-                PermissionType::ServerPerms(Permissions::MANAGE_CHANNELS),
-                Some(Box::new(move |ctx, command, params| {
-                    Box::pin(async {
-                        // Set announcement channel if it's been supplied.
-                        if let Some(channel_opt) = params.iter().find(|opt| opt.name == "channel") {
+                "refresh_interval",
+                "The frequency at which the nickname lottery can occur, changing a single random user's nickname.",
+                PermissionType::ServerPerms(Permissions::MANAGE_NICKNAMES),
+                None,
+            )
+            .add_variant(
+                Command::new(
+                    "set",
+                    "Set a custom interval range for this server. Does not affect April Fool's day.",
+                    PermissionType::ServerPerms(Permissions::MANAGE_NICKNAMES),
+                    Some(Box::new(move |ctx, command, params| {
+                        Box::pin(async {
+                            let min = get_param!(params, Integer, "min");
+                            let max = get_param!(params, Integer, "max");
+
                             let mut data = crate::acquire_data_handle!(write ctx);
                             let config = data.get_mut::<Config>().unwrap();
                             let guild = config.guild_mut(&command.guild_id.unwrap());
-                            if let CommandDataOptionValue::Channel(channel) = &channel_opt.value {
-                                let channel = channel.to_channel(&ctx.http()).await?;
-                                guild
-                                    .nickname_lottery_data_mut()
-                                    .set_complaints_channel(Some(channel.id()));
-                                config.save();
-                            }
-                        };
+                            let nickname_lottery_data = guild.nickname_lottery_data_mut();
+                            nickname_lottery_data.set_refresh_interval(Some((*min as u64, *max as u64)));
+                            config.save();
+                            crate::drop_data_handle!(data);
 
-                        // Set title override if it's been supplied.
-                        if let Some(title_opt) =
-                            params.iter().find(|opt| opt.name == "title_override")
-                        {
+                            let format_time = |secs| -> String {
+                                let seconds = secs % 60;
+                                let minutes = (secs / 60) % 60;
+                                let hours = (secs / 60 / 60) % 24;
+                                let days = secs / 60 / 60 / 24;
+
+                                format!("{days}d {hours}h {minutes}m {seconds}s")
+                            };
+
+                            let resp = format!(
+                                "**Nickname lottery refresh interval updated**
+Minimum time between lotteries: {}
+Maximum time between lotteries: {}",
+                                format_time(min), format_time(max)
+                            );
+                            Ok(Some(ActionResponse::new(create_raw_embed(resp), true)))
+                        })
+                    })),
+                )
+                .add_option(crate::command::Option::new(
+                    "min",
+                    "The minimum time, in seconds, between nickname changes.",
+                    OptionType::IntegerInput(Some(1_800), None),
+                    true,
+                ))
+                .add_option(crate::command::Option::new(
+                    "max",
+                    "The maximum time, in seconds, between nickname changes.",
+                    OptionType::IntegerInput(Some(1_800), None),
+                    true,
+                )),
+            )
+            .add_variant(
+                Command::new(
+                    "reset",
+                    "Revert back to the default interval.",
+                    PermissionType::ServerPerms(Permissions::MANAGE_NICKNAMES),
+                    Some(Box::new(move |ctx, command, _params| {
+                        Box::pin(async {
                             let mut data = crate::acquire_data_handle!(write ctx);
                             let config = data.get_mut::<Config>().unwrap();
                             let guild = config.guild_mut(&command.guild_id.unwrap());
                             let lottery_data = guild.nickname_lottery_data_mut();
-                            if let CommandDataOptionValue::String(title_override) = &title_opt.value
-                            {
-                                lottery_data.set_title_override(Some(title_override.to_owned()));
-                                config.save();
-                            }
-                        };
+                            lottery_data.set_refresh_interval(None);
+                            config.save();
+                            crate::drop_data_handle!(data);
 
-                        let data = crate::acquire_data_handle!(read ctx);
-                        let guild = get_guild(&data, &command.guild_id.unwrap());
-                        let lottery_data = &guild.unwrap().nickname_lottery_data();
-                        let resp = format!(
-                            "**Nickname lottery complaints channel updated!**
+                            Ok(Some(ActionResponse::new(
+                                create_raw_embed("Refresh interval has been reset to default."),
+                                true,
+                            )))
+                        })
+                    })),
+                )
+            )
+        )
+        .add_variant(
+            Command::new(
+                "announcements",
+                "Commands to manage nickname lottery announcements.",
+                PermissionType::ServerPerms(Permissions::MANAGE_CHANNELS),
+                None,
+            )
+            .add_variant(
+                Command::new(
+                    "configure",
+                    "Configure announcements when the bot fails to change a user's nickname.",
+                    PermissionType::ServerPerms(Permissions::MANAGE_CHANNELS),
+                    Some(Box::new(move |ctx, command, params| {
+                        Box::pin(async {
+                            // Set announcement channel if it's been supplied.
+                            if let Some(channel_opt) =
+                                params.iter().find(|opt| opt.name == "channel")
+                            {
+                                let mut data = crate::acquire_data_handle!(write ctx);
+                                let config = data.get_mut::<Config>().unwrap();
+                                let guild = config.guild_mut(&command.guild_id.unwrap());
+                                if let CommandDataOptionValue::Channel(channel) = &channel_opt.value
+                                {
+                                    let channel = channel.to_channel(&ctx.http()).await?;
+                                    guild
+                                        .nickname_lottery_data_mut()
+                                        .set_channel(Some(channel.id()));
+                                    config.save();
+                                }
+                            };
+
+                            // Set title override if it's been supplied.
+                            if let Some(title_opt) =
+                                params.iter().find(|opt| opt.name == "title_override")
+                            {
+                                let mut data = crate::acquire_data_handle!(write ctx);
+                                let config = data.get_mut::<Config>().unwrap();
+                                let guild = config.guild_mut(&command.guild_id.unwrap());
+                                let lottery_data = guild.nickname_lottery_data_mut();
+                                if let CommandDataOptionValue::String(title_override) =
+                                    &title_opt.value
+                                {
+                                    lottery_data
+                                        .set_title_override(Some(title_override.to_owned()));
+                                    config.save();
+                                }
+                            };
+
+                            let data = crate::acquire_data_handle!(read ctx);
+                            let guild = get_guild(&data, &command.guild_id.unwrap());
+                            let lottery_data = &guild.unwrap().nickname_lottery_data();
+                            let resp = format!(
+                                "**Nickname lottery complaints channel updated!**
 Channel: {}
 Title text: {}",
-                            lottery_data
-                                .complaints_channel()
-                                .unwrap()
-                                .to_channel(&ctx.http())
-                                .await?,
-                            lottery_data.title()
-                        );
-                        Ok(Some(ActionResponse::new(create_raw_embed(resp), true)))
+                                lottery_data
+                                    .channel()
+                                    .unwrap()
+                                    .to_channel(&ctx.http())
+                                    .await?,
+                                lottery_data.title()
+                            );
+                            Ok(Some(ActionResponse::new(create_raw_embed(resp), true)))
+                        })
+                    })),
+                )
+                .add_option(crate::command::Option::new(
+                    "channel",
+                    "The channel to announce timeouts in.",
+                    OptionType::Channel(Some(vec![ChannelType::Text])),
+                    false,
+                ))
+                .add_option(crate::command::Option::new(
+                    "title_override",
+                    "Text to prepend before the timeout counter message.",
+                    OptionType::StringInput(None, None),
+                    false,
+                )),
+            )
+            .add_variant(Command::new(
+                "stop",
+                "Stop all announcements. Unsets all configuration values.",
+                PermissionType::ServerPerms(Permissions::MANAGE_CHANNELS),
+                Some(Box::new(move |ctx, command, _params| {
+                    Box::pin(async {
+                        let mut data = crate::acquire_data_handle!(write ctx);
+                        let config = data.get_mut::<Config>().unwrap();
+                        let guild = config.guild_mut(&command.guild_id.unwrap());
+                        let lottery_data = guild.nickname_lottery_data_mut();
+                        lottery_data.set_channel(None);
+                        lottery_data.set_title_override(None);
+                        config.save();
+                        crate::drop_data_handle!(data);
+
+                        Ok(Some(ActionResponse::new(
+                            create_raw_embed("Announcements have been uninitialised."),
+                            true,
+                        )))
                     })
                 })),
-            )
-            .add_option(crate::command::Option::new(
-                "channel",
-                "The channel to announce timeouts in.",
-                OptionType::Channel(Some(vec![ChannelType::Text])),
-                false,
-            ))
-            .add_option(crate::command::Option::new(
-                "title_override",
-                "Text to prepend before the timeout counter message.",
-                OptionType::StringInput(None, None),
-                false,
             )),
-        )
-        .add_variant(Command::new(
-            "stop_announcements",
-            "Stop all announcements. Unsets all configuration values.",
-            PermissionType::ServerPerms(Permissions::MANAGE_CHANNELS),
-            Some(Box::new(move |ctx, command, _params| {
-                Box::pin(async {
-                    let mut data = crate::acquire_data_handle!(write ctx);
-                    let config = data.get_mut::<Config>().unwrap();
-                    let guild = config.guild_mut(&command.guild_id.unwrap());
-                    let lottery_data = guild.nickname_lottery_data_mut();
-                    lottery_data.set_complaints_channel(None);
-                    lottery_data.set_title_override(None);
-                    config.save();
-                    crate::drop_data_handle!(data);
-
-                    Ok(Some(ActionResponse::new(
-                        create_raw_embed("Announcements have been uninitialised."),
-                        true,
-                    )))
-                })
-            })),
-        ))]
+        )]
     }
 }
 
 impl NicknameLottery {
     pub async fn guild_init(ctx: Context, g: Guild) {
         // between 30 minutes and 5 days
-        let between = rand::distributions::Uniform::from(REFRESH_INTERVAL.0..REFRESH_INTERVAL.1);
+        let mut interval = DEFAULT_REFRESH_INTERVAL;
+        let mut between = rand::distributions::Uniform::from(
+            DEFAULT_REFRESH_INTERVAL.0..DEFAULT_REFRESH_INTERVAL.1,
+        );
         loop {
+            // Use a different distribution if the guild's set a different refresh interval.
+            let data = crate::acquire_data_handle!(read ctx);
+            if let Some(guild) = get_guild(&data, &g.id) {
+                let lottery_data = guild.nickname_lottery_data();
+                let i = if let Some(i) = lottery_data.refresh_interval() {
+                    *i
+                } else {
+                    DEFAULT_REFRESH_INTERVAL
+                };
+                if interval.0 != i.0 || interval.1 != i.1 {
+                    interval = i;
+                    between = rand::distributions::Uniform::from(interval.0..interval.1);
+                }
+            }
+            crate::drop_data_handle!(data);
             let now = chrono::Utc::now();
             let is_april_fools = now.month() == 4 && now.day() == 1;
             if cfg!(not(debug_assertions)) {
@@ -416,7 +976,9 @@ _Nickname changes are disabled for this guild until next initialisation._",
                 if let Some(user) = lottery_data.get_random_user() {
                     if let Ok(member) = g.member(&ctx.http(), user).await {
                         let user = &member.user;
-                        if let Some(mut new_nick) = lottery_data.get_nickname_for_user(&user.id) {
+                        if let Some(mut new_nick) =
+                            lottery_data.get_nickname_for_user(&user.id).cloned()
+                        {
                             let old_nick = member.display_name();
                             // If feature `stream-indicator` is enabled, we want to preserve any applied streaming prefix, in case we're changing the nickname mid-stream.
                             #[cfg(feature = "stream-indicator")]
@@ -452,7 +1014,7 @@ _Nickname changes are disabled for this guild until next initialisation._",
                                 );
                             }
                             if post_name_change {
-                                if let Some(channel_id) = lottery_data.complaints_channel() {
+                                if let Some(channel_id) = lottery_data.channel() {
                                     let channel = match channel_id.to_channel(&ctx.http()).await {
                                         Ok(channel) => channel.guild(),
                                         Err(_) => None,
@@ -504,61 +1066,64 @@ _Nickname changes are disabled for this guild until next initialisation._",
 mod test {
     use serenity::model::prelude::UserId;
 
-    use super::NicknameLotteryGuildData;
-
-    #[test]
-    fn test_nickname_strings() {
-        assert_eq!(
-            NicknameLotteryGuildData::construct_nickname_string(
-                &NicknameLotteryGuildData::deconstruct_nickname_string(
-                    &"Nick1
-Nick number 2    
-     Nick_numerus_tres
-
-A very long nickname that exceeds 30 characters
-etc"
-                )
-            ),
-            "Nick1
-Nick number 2
-Nick_numerus_tres
-A very long nickname that exce
-etc"
-        )
-    }
+    use super::{NicknameData, NicknameLotteryGuildData};
 
     #[test]
     fn test_setting_and_selecting_nicknames() {
-        let users = [UserId::from(0), UserId::from(1)];
+        let users = [UserId::from(1), UserId::from(2)];
         let mut data: NicknameLotteryGuildData = NicknameLotteryGuildData::default();
         assert_eq!(data.get_nickname_for_user(&users[0]), None);
         assert_eq!(data.get_nickname_for_user(&users[1]), None);
-        data.set_user_nicknames(&users[0], &["user0"]);
-        data.set_user_nicknames(&users[1], &["user1"]);
+        data.add_user_nickname(
+            &users[0],
+            NicknameData {
+                nickname: String::from("user0"),
+                author: None,
+                time: None,
+                context: None,
+            },
+        );
+        data.add_user_nickname(
+            &users[1],
+            NicknameData {
+                nickname: String::from("user1"),
+                author: None,
+                time: None,
+                context: None,
+            },
+        );
         assert_eq!(
             data.get_nickname_for_user(&users[0]),
-            Some("user0".to_string())
+            Some(&"user0".to_string())
         );
         assert_eq!(
             data.get_nickname_for_user(&users[1]),
-            Some("user1".to_string())
+            Some(&"user1".to_string())
         );
-        data.set_user_nicknames(&users[0], &[]);
+        data.remove_user_nickname(&users[0], 1);
         assert_eq!(data.get_nickname_for_user(&users[0]), None);
         assert_eq!(
             data.get_nickname_for_user(&users[1]),
-            Some("user1".to_string())
+            Some(&"user1".to_string())
         );
     }
 
     #[test]
     fn select_random_user() {
-        let users = [UserId::from(0)];
+        let users = [UserId::from(1)];
         let mut data: NicknameLotteryGuildData = NicknameLotteryGuildData::default();
         assert_eq!(data.get_random_user(), None);
-        data.set_user_nicknames(&users[0], &["user0"]);
+        data.add_user_nickname(
+            &users[0],
+            NicknameData {
+                nickname: String::from("user0"),
+                author: None,
+                time: None,
+                context: None,
+            },
+        );
         assert_eq!(data.get_random_user(), Some(users[0].clone()));
-        data.set_user_nicknames(&users[0], &[]);
+        data.remove_user_nickname(&users[0], 1);
         assert_eq!(data.get_random_user(), None);
     }
 }

--- a/src/subsystems/nickname_lottery.rs
+++ b/src/subsystems/nickname_lottery.rs
@@ -411,7 +411,7 @@ Consider checking their nickname list for valid number to remove.",
                             Ok(Some(ActionResponse::new(
                                 create_raw_embed(
                                     format!("**Removed nickname '{}' for {}**
-Originally added by {} (<t:{}:F>)
+Originally added by {} ({})
 **Context:**
 {}",
                                     nickname.nickname(), user.mention(),
@@ -419,7 +419,7 @@ Originally added by {} (<t:{}:F>)
                                             .map(|uid| uid.mention().to_string())
                                             .unwrap_or("`user not known`".to_string()),
                                     nickname.time()
-                                            .map(|time| time.timestamp().to_string())
+                                            .map(|time| format!("<t:{}:F>", time.timestamp().to_string()))
                                             .unwrap_or("`time not known`".to_string()),
                                     nickname.context()
                                             .unwrap_or(&"No context provided.".to_string()),
@@ -616,7 +616,7 @@ Consider checking their nickname list for valid number to remove.",
                             Ok(Some(ActionResponse::new(
                                 create_raw_embed(
                                     format!("**Nickname '{}' for {}**
-Originally added by {} (<t:{}:F>)
+Originally added by {} ({})
 **Context:**
 {}",
                                     nickname.nickname(), user.mention(),
@@ -624,7 +624,7 @@ Originally added by {} (<t:{}:F>)
                                             .map(|uid| uid.mention().to_string())
                                             .unwrap_or("`user not known`".to_string()),
                                     nickname.time()
-                                            .map(|time| time.timestamp().to_string())
+                                            .map(|time| format!("<t:{}:F>", time.timestamp().to_string()))
                                             .unwrap_or("`time not known`".to_string()),
                                     nickname.context()
                                             .unwrap_or(&"No context provided.".to_string()),

--- a/src/subsystems/timeout_monitor.rs
+++ b/src/subsystems/timeout_monitor.rs
@@ -246,7 +246,7 @@ Announcement text: {}",
                             times = iter.map(|(_, utd)| {
                                 let seconds = utd.total_time % 60;
                                 let minutes = (utd.total_time / 60) % 60;
-                                let hours = (utd.total_time / 60 / 60) % 60;
+                                let hours = utd.total_time / 60 / 60;
                                 format!("{hours}h {minutes}m {seconds}s")
                             }).collect::<Vec<String>>().join("\n");
                         }


### PR DESCRIPTION
- Allow overriding the lottery refresh interval on a per-guild basis. Changes to this take effect after the next lottery refresh.
- Store information about the user who added a nickname, and the time it was added.
- Allow specifying context behind a given nickname.

Plus some drive-by changes to the timeout monitor (fix display of number of hours), serenity handler now supports double nesting, and OpenSSL's minimum version was bumped.

## Config Compatibility Break
These changes break compatibility with prior config files. Migration instructions:
The sections of the form: 
```toml
[guilds.ID.nickname_lottery_data.user_specific_nicknames]
ID1 = [
  "nickname1",
  "nickname2",
  # ...
]
ID2 = [
  "n1",
  "n2",
  # ...
]
# ...
```
must be adjusted to be of the following form:
```toml
[[guilds.ID.nickname_lottery_data.user_specific_nicknames.ID1]]
nickname = "nickname1"
[[guilds.ID.nickname_lottery_data.user_specific_nicknames.ID1]]
nickname = "nickname2"
# ...
[[guilds.ID.nickname_lottery_data.user_specific_nicknames.ID2]]
nickname = "n1"
[[guilds.ID.nickname_lottery_data.user_specific_nicknames.ID2]]
nickname = "n2"
# ...
```
Optionally, `author`, `time`, and `context` may be specified for each entry, where `author` is a Discord UserID number (encapsulated in a string), `time` is an ISO 8601 string, and `context` is a string. Not including these fields will still work for a minimal functioning migration to the new feature, but information about those nicknames will be lacking compared to any newly created nicknames from this point on.